### PR TITLE
Add auto-importer for custom tags

### DIFF
--- a/src/components/Video.tsx
+++ b/src/components/Video.tsx
@@ -16,7 +16,7 @@ interface VideoProps {
   src: string
 }
 
-const Video: React.FC<VideoProps> = ({ src }) => {
+export const Video: React.FC<VideoProps> = ({ src }) => {
   // @ts-ignore
   const video = videos[src]
   return <NextVideo src={video} autoPlay muted loop className="pt-5"/>

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,0 +1,40 @@
+import { Button } from './Button'
+import { Callout } from './Callout'
+import { DocsHeader } from './DocsHeader'
+import { DocsLayout } from './DocsLayout'
+import { Fence } from './Fence'
+import { Hero } from './Hero'
+import { HeroBackground } from './HeroBackground'
+import { Icon } from './Icon'
+import { Layout } from './Layout'
+import { Logo } from './Logo'
+import { MobileNavigation } from './MobileNavigation'
+import { Navigation } from './Navigation'
+import { PrevNextLinks } from './PrevNextLinks'
+import { Prose } from './Prose'
+import { QuickLinks, QuickLink } from './QuickLinks'
+import { Search } from './Search'
+import { TableOfContents } from './TableOfContents'
+import { Video } from './Video'
+
+export default {
+  Button,
+  Callout,
+  DocsHeader,
+  DocsLayout,
+  Fence,
+  Hero,
+  HeroBackground,
+  Icon,
+  Layout,
+  Logo,
+  MobileNavigation,
+  Navigation,
+  PrevNextLinks,
+  Prose,
+  QuickLinks,
+  QuickLink,
+  Search,
+  TableOfContents,
+  Video,
+}

--- a/src/markdoc/tags.js
+++ b/src/markdoc/tags.js
@@ -1,9 +1,23 @@
-import { Callout } from '@/components/Callout'
-import { QuickLink, QuickLinks } from '@/components/QuickLinks'
-import Video from '@/components/Video'
 import React from 'react'
 
+import components from '@/components'
+
+function toSnakeCase(str) {
+  return (str[0] + str.substr(1).replace(/([A-Z])/g, '-$1')).toLowerCase()
+}
+
+// Import all the components and generate tag stubs for each.
+// If you want to expose attributes, you have to override the entry
+// with the configuration you need.
+const componentTags = Object.fromEntries(
+  Object.keys(components).map((key) => [
+    toSnakeCase(key),
+    { render: components[key] },
+  ]),
+)
+
 const tags = {
+  ...componentTags,
   callout: {
     attributes: {
       title: { type: String },
@@ -14,7 +28,7 @@ const tags = {
         errorLevel: 'critical',
       },
     },
-    render: Callout,
+    render: components.Callout,
   },
   figure: {
     selfClosing: true,
@@ -31,19 +45,16 @@ const tags = {
       </figure>
     ),
   },
-  'quick-links': {
-    render: QuickLinks,
-  },
-  'video': {
-    render: Video,
+  video: {
+    render: components.Video,
     selfClosing: true,
     attributes: {
-      src: { type: String }
-    }
+      src: { type: String },
+    },
   },
   'quick-link': {
     selfClosing: true,
-    render: QuickLink,
+    render: components.QuickLink,
     attributes: {
       title: { type: String },
       description: { type: String },


### PR DESCRIPTION
To use it, you have to add the import to components/index.tsx so it is exposed.

We could use dynamic imports from webpack or glob over all the files in that directory when the server starts up but that does not seem worth the effort.

Personally, I do not think this PR is adding much value because you still have to do the re-export from `index.tsx` but putting it up for consideration