### PR TITLE
re-add positioning

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -51,7 +51,7 @@ function Header() {
   return (
     <header
       className={clsx(
-        ' sticky top-0 z-50 border-b px-12 py-5 shadow-none shadow-gray-900/5 transition duration-500 sm:px-12  sm:py-5 lg:px-12 dark:border-gray-800 dark:bg-gray-900 dark:bg-gray-900/95 dark:shadow-none dark:shadow-gray-900/5 dark:backdrop-blur dark:backdrop-blur dark:transition dark:duration-500',
+        'sticky top-0 z-50 border-b px-12 py-5 shadow-none shadow-gray-900/5 transition duration-500 sm:px-12  sm:py-5 lg:px-12 dark:border-gray-800 dark:bg-gray-900 dark:bg-gray-900/95 dark:shadow-none dark:shadow-gray-900/5 dark:backdrop-blur dark:transition dark:duration-500',
         isScrolled
           ? 'backdrop-blur dark:bg-gray-900/95 [@supports(backdrop-filter:blur(0))]:bg-white/45 dark:[@supports(backdrop-filter:blur(0))]:bg-gray-900/75'
           : 'bg-transparent',
@@ -112,7 +112,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
               <div className="absolute inset-y-0 right-0 w-[50vw] bg-gray-50 dark:hidden" />
               <div className="absolute bottom-0 right-0 top-16 hidden h-12 w-px bg-gradient-to-t from-gray-800 dark:block" />
               <div className="absolute bottom-0 right-0 top-28 hidden w-px bg-gray-800 dark:block" />
-              <div className="sticky  -ml-0.5 h-[calc(100vh-4.75rem)] w-72 overflow-y-auto overflow-x-hidden py-8 pl-0.5 pr-2 xl:pr-2">
+              <div className="sticky top-[4.75rem] -ml-0.5 h-[calc(100vh-4.75rem)] w-72 overflow-y-auto overflow-x-hidden py-8 pl-0.5 pr-2 xl:pr-2">
                 <Navigation />
               </div>
             </>

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -65,7 +65,7 @@ export function TableOfContents({
   return (
     <div
       data-testid="table-of-contents"
-      className="hidden py-8 xl:sticky xl:-mr-6 xl:block xl:h-[calc(100vh-4.75rem)] xl:flex-none xl:overflow-y-auto xl:pr-6"
+      className="hidden py-8 xl:sticky xl:-mr-6 xl:block xl:h-[calc(100vh-4.75rem)] xl:flex-none xl:overflow-y-auto xl:pr-6 xl:top-[4.75rem] xl:py-16"
     >
       <nav aria-labelledby="on-this-page-title" className="w-56">
         {tableOfContents.length > 0 && (


### PR DESCRIPTION
the issue was caused by removing `top` css property. in order for `sticky` position to work, top property must be specified. fix was applied both for navigation and toc components