### PR TITLE
Fix Mixpanel error

### DIFF
--- a/src/components/Analytics.tsx
+++ b/src/components/Analytics.tsx
@@ -21,10 +21,6 @@ export default function Analytics() {
         src="/stats/script.js"
         data-website-id="9dab9357-6fa2-48ab-966a-82c4e1bb67fe"
       ></script>
-      <script
-        async
-        src="https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js"
-      ></script>
     </>
   )
 }


### PR DESCRIPTION
Closes PRO-260.

Mixpanel was already seems to be working. We had been importing the SDK twice: once through node_modules and once via a script tag. I have removed the script tag and verified it's working. Example event: https://mixpanel.com/project/2349904/view/2894968/app/profile#distinct_id=%24device%3A18f17626d0793c-008f3b073f824f8-422b2e31-13c680-18f17626d0893c

Other things to note:
- Mixpanel can not bypass adblocker
- Mixpanel by default honors DNT header. While testing disable "Do not track" in your browse