### PR TITLE
fix: homepage mobile styling

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -83,7 +83,7 @@ const miniCards: CardAttributes[] = [
 
 export default function Page() {
   return (
-    <div data-test-id="page" className="mx-auto flex max-w-4xl flex-col py-8">
+    <div data-test-id="page" className="mx-auto flex max-w-4xl flex-col px-4 py-8">
       <Hero />
       <h2 className="py-8 text-2xl font-semibold">Topics</h2>
       <div className="grid place-items-center gap-4 pb-20 md:grid-cols-2 lg:grid-cols-3">

--- a/src/components/MiniCard.tsx
+++ b/src/components/MiniCard.tsx
@@ -9,7 +9,7 @@ export default function MiniCard({
   href,
 }: CardAttributes) {
   return (
-    <Link href={href}>
+    <Link href={href} className="w-full">
       <li
         key={title}
         className="col-span-1 flex rounded-md bg-gray-100/70 bg-opacity-30 shadow-md transition-colors hover:bg-gray-200/90 dark:bg-gray-950/50 dark:hover:bg-gray-900/50"


### PR DESCRIPTION
This PR:

1) Adds padding to the docs homepage
2) Fixes the width of MiniCards for some mobile

# Padding

| Before | After | 
| ---- | ---- |
| <img src="https://github.com/replayio/docs/assets/9100169/8f25efb9-4551-437e-bf07-bab4ce227f30" height="500"/> | <img src="https://github.com/replayio/docs/assets/9100169/82fb0e17-8c60-445f-a952-39589d1d0d2f" height="500"/> |

> Added a 16px border to showcase the issues with padding

# Width of MiniCards


| Before | After | 
| ---- | ---- |
| <img src="https://github.com/replayio/docs/assets/9100169/ba757465-c0b9-4c2e-b239-0a154e04a6f9" height="500"/> | <img src="https://github.com/replayio/docs/assets/9100169/86e07669-9e97-4e01-bab7-154a4a99ae45" height="500"/> |


