### PR TITLE
Ignore scroll update immediately after hash change

### DIFF
--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -36,7 +36,14 @@ export function TableOfContents({
     if (tableOfContents.length === 0) return
 
     const headings = getHeadings(tableOfContents)
+    let ignoreScrollUpdate = false
+
     function findRightSection() {
+      // Ignore scroll updates immediately after a hash change
+      if (ignoreScrollUpdate) {
+        ignoreScrollUpdate = false
+        return
+      }
       let top = window.scrollY
       let current = headings[0].id
       for (let heading of headings) {
@@ -53,6 +60,7 @@ export function TableOfContents({
     const hash = window.location.hash.replace('#', '')
     if (hash) {
       setCurrentSection(hash)
+      ignoreScrollUpdate = true
     }
 
     return () => {


### PR DESCRIPTION
Follow up on: https://github.com/replayio/docs/pull/127 Ignoring the scroll update immediately after hash change, otherwise it is conflicting and stepping over the hash change event.

Related PRO-254.