### PR TITLE
Remove redundant `as any` from Playwright-related docs

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,7 +20,7 @@ const config: PlaywrightTestConfig = {
   projects: [
     {
       name: 'replay-chromium',
-      use: { ...(replayDevices['Replay Chromium'] as any) },
+      use: { ...replayDevices['Replay Chromium'] },
     },
     {
       name: 'chromium',

--- a/src/app/ci-workflows/upload-strategies/page.md
+++ b/src/app/ci-workflows/upload-strategies/page.md
@@ -1,6 +1,6 @@
 ---
 title: Upload strategies
-description: When you run tests and create recordings, they are stored locally. You can opt to upload them automatically or define your own uploading strategy. All uploaded recordings become accessible in the Replay App. 
+description: When you run tests and create recordings, they are stored locally. You can opt to upload them automatically or define your own uploading strategy. All uploaded recordings become accessible in the Replay App.
 ---
 
 {% callout %}
@@ -50,7 +50,7 @@ By default, all test replays are uploaded no matter the result. If you want to u
     projects: [
       {
         name: "replay-chromium",
-        use: { ...replayDevices["Replay Chromium"] as any },
+        use: { ...replayDevices["Replay Chromium"] },
       }
     ],
   };
@@ -120,7 +120,7 @@ The recording metadata includes some details about the source control including 
     projects: [
       {
         name: "replay-chromium",
-        use: { ...replayDevices["Replay Chromium"] as any },
+        use: { ...replayDevices["Replay Chromium"] },
       }
     ],
   };
@@ -190,7 +190,7 @@ If you've adopted one the configurations above but would also like to periodical
     projects: [
       {
         name: "replay-chromium",
-        use: { ...replayDevices["Replay Chromium"] as any },
+        use: { ...replayDevices["Replay Chromium"] },
       }
     ],
   };

--- a/src/app/test-runners/playwright/github-actions/page.md
+++ b/src/app/test-runners/playwright/github-actions/page.md
@@ -22,7 +22,7 @@ const config: PlaywrightTestConfig = {
   projects: [
     {
       name: "replay-chromium",
-      use: { ...replayDevices["Replay Chromium"] as any },
+      use: { ...replayDevices["Replay Chromium"] },
     }
   ],
 };

--- a/src/app/test-runners/playwright/record-your-first-replay/page.md
+++ b/src/app/test-runners/playwright/record-your-first-replay/page.md
@@ -57,7 +57,7 @@ const config: PlaywrightTestConfig = {
   projects: [
     {
       name: 'replay-chromium',
-      use: { ...(replayDevices['Replay Chromium'] as any) },
+      use: { ...replayDevices['Replay Chromium'] },
     },
   ],
 }

--- a/src/app/test-runners/playwright/recording-tests-locally.md
+++ b/src/app/test-runners/playwright/recording-tests-locally.md
@@ -33,7 +33,7 @@ const config: PlaywrightTestConfig = {
   projects: [
     {
       name: 'replay-chromium',
-      use: { ...(replayDevices['Replay Chromium'] as any) },
+      use: { ...replayDevices['Replay Chromium'] },
     },
   ],
 }


### PR DESCRIPTION
From what I can tell this is redundant. If we manage to repro the problem with the suggested changes then we should fix the problem at the core (fix the types) and avoid telling people that they have to `as any` in their code.

Some extra context: https://github.com/replayio/replay-cli/pull/420