### PR TITLE
fix: second link on quickstart guide should now have an underline

### DIFF
--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -30,7 +30,7 @@
   margin-top: 4rem ;
 }
 
-.prose-a\:shadow-\[inset_0_-2px_0_0_var\(--tw-prose-background\2c \#fff\)\2c inset_0_calc\(-1\*\(var\(--tw-prose-underline-size\2c 4px\)\+2px\)\)_0_0_var\(--tw-prose-underline\2c theme\(colors\.sky\.300\)\)\] :is(:where(a):not(:where([class~="not-prose"],[class~="not-prose"] *))):has(code) {
+.prose-a\:shadow-\[inset_0_-2px_0_0_var\(--tw-prose-background\2c \#fff\)\2c inset_0_calc\(-1\*\(var\(--tw-prose-underline-size\2c 4px\)\+2px\)\)_0_0_var\(--tw-prose-underline\2c theme\(colors\.sky\.300\)\)\] :is(:where(a):not(:where(li > a,[class~="not-prose"],[class~="not-prose"] *))):has(code) {
   box-shadow: none;
 }
 


### PR DESCRIPTION
| Before | After |
| --- | --- |
| ![image](https://github.com/replayio/docs/assets/9100169/c09b4021-b83c-47b5-af29-34cee15d6a66) |  ![image](https://github.com/replayio/docs/assets/9100169/2efea518-bc44-4e78-ac27-ac44c6970d96) |

Solves: [DEV-453](https://linear.app/replay/issue/DEV-453/consolelog-in-quick-start-guide-should-have-a-link-but-doesnt)