### PR TITLE
docs: fix reporter info in playwright setup

### DIFF
--- a/src/app/test-runners/playwright/github-actions/page.md
+++ b/src/app/test-runners/playwright/github-actions/page.md
@@ -12,13 +12,19 @@ In the setup below, we update the `playwright.config.ts` file to use the Replay 
 
 ```jsx {% fileName="playwright.config.ts" lineNumbers=true %}
 import { PlaywrightTestConfig, devices } from "@playwright/test";
-import { devices as replayDevices } from "@replayio/playwright";
+import {
+    createReplayReporterConfig,
+    devices as replayDevices,
+} from "@replayio/playwright";
 
 const config: PlaywrightTestConfig = {
-  reporter: [["@replayio/playwright/reporter", {
-    apiKey: process.env.REPLAY_API_KEY,
-    upload: true
-  }], ['line']],
+  reporter: [
+      createReplayReporterConfig({
+          apiKey: process.env.REPLAY_API_KEY,
+          upload: true,
+      }),
+      ['line']
+  ],
   projects: [
     {
       name: "replay-chromium",

--- a/src/app/test-runners/playwright/record-your-first-replay/page.md
+++ b/src/app/test-runners/playwright/record-your-first-replay/page.md
@@ -43,20 +43,20 @@ We recommend using the current `@alpha` version of this plugin. It's more robust
 
 ## Update your configuration
 
-```js {% fileName="playwright.config.ts" highlight=[2,"7-13","17-20"] lineNumbers=true %}
+```js {% fileName="playwright.config.ts" highlight=["2-5","10-13","17-20"] lineNumbers=true %}
 import { PlaywrightTestConfig, devices } from '@playwright/test'
-import { devices as replayDevices } from '@replayio/playwright'
+import {
+  createReplayReporterConfig,
+  devices as replayDevices,
+} from "@replayio/playwright";
 import 'dotenv/config'
 
 const config: PlaywrightTestConfig = {
   reporter: [
-    [
-      '@replayio/playwright/reporter',
-      {
-        apiKey: process.env.REPLAY_API_KEY,
-        upload: true,
-      },
-    ],
+    createReplayReporterConfig({
+      apiKey: process.env.REPLAY_API_KEY,
+      upload: true,
+    }),
     ['line'],
   ],
   projects: [


### PR DESCRIPTION
This PR migrates to the new `reporter` setup for Playwright

Solves: [DEV-429](https://linear.app/replay/issue/DEV-429/playwright-plug-in-instructions-show-wrong-reporter-info)