### PR TITLE
docs: fix typo and add more descriptive link

### DIFF
--- a/src/app/replay-devtools/overview/page.md
+++ b/src/app/replay-devtools/overview/page.md
@@ -7,7 +7,7 @@ description: Inspect your application with perfect reproducibility as if it were
 
 ## Overview
 
-When you open a replay, you're able to inspect your application with Replay DevTools as if you were there when it iniitally ran because there is a browser running in the cloud that thinks it's running at the original point in time on the original computer. [learn more](/time-travel-intro/what-is-time-travel)
+When you open a replay, you're able to inspect your application with Replay DevTools as if you were there when it initially ran because there is a browser running in the cloud that thinks it's running at the original point in time on the original computer. [Learn more about how this works.](/time-travel-intro/what-is-time-travel)
 
 ## Browser DevTools
 


### PR DESCRIPTION
This PR fixes a small typo in the Overview page and adds a more descriptive link to be read out loud with a screen reader