### PR TITLE
Fix link underlines

### DIFF
--- a/src/components/Prose.tsx
+++ b/src/components/Prose.tsx
@@ -21,7 +21,13 @@ export function Prose<T extends React.ElementType = 'div'>({
         // links
         'prose-a:font-semibold dark:prose-a:text-sky-400',
         // link underline
-        'prose-a:no-underline prose-a:shadow-[inset_0_-2px_0_0_var(--tw-prose-background,#fff),inset_0_calc(-1*(var(--tw-prose-underline-size,4px)+2px))_0_0_var(--tw-prose-underline,theme(colors.sky.300))] hover:prose-a:[--tw-prose-underline-size:6px] dark:[--tw-prose-background:theme(colors.slate.900)] dark:prose-a:shadow-[inset_0_calc(-1*var(--tw-prose-underline-size,2px))_0_0_var(--tw-prose-underline,theme(colors.sky.800))] dark:hover:prose-a:[--tw-prose-underline-size:6px]',
+        `
+        prose-a:no-underline
+        prose-a:shadow-[inset_0_calc(-1*var(--tw-prose-underline-size,2px))_0_0_var(--tw-prose-underline,theme(colors.sky.300))]
+         hover:prose-a:[--tw-prose-underline-size:4px]
+         dark:[--tw-prose-background:theme(colors.slate.900)]
+         dark:prose-a:shadow-[inset_0_calc(-1*var(--tw-prose-underline-size,2px))_0_0_var(--tw-prose-underline,theme(colors.sky.800))]
+         `,
         // pre
         'prose-pre:rounded-xl prose-pre:bg-gray-900 prose-pre:shadow-lg dark:prose-pre:bg-gray-800/60 dark:prose-pre:shadow-none dark:prose-pre:ring-1 dark:prose-pre:ring-gray-300/10',
         // hr


### PR DESCRIPTION
I noticed during my audit that the underlines are different depending on if you are in light mode or dark. Here's the before:

https://github.com/replayio/docs/assets/5903784/b361c4f7-543a-4060-ba9f-1cf7f4215af5

Here's my attempt at improving it:

https://github.com/replayio/docs/assets/5903784/fb5e83d7-0818-4954-b93a-97f26a7f7ee8

This is now consistent at least. I have also bumped the hover state down in size. It's still a significant enough difference that you can definitely tell the hovered one apart, but it doesn't overlap the text as much. I found hovered links difficult to read in the previous iteration, but I'm open to feedback about that piece of the change.