### PR TITLE
Fix CI Section

### DIFF
--- a/src/app/test-runners/playwright/record-your-first-replay/page.md
+++ b/src/app/test-runners/playwright/record-your-first-replay/page.md
@@ -125,21 +125,13 @@ Running 1 test using 1 worker
   1 passed (2.1s)
 ```
 
-### Integrate into your CI workflow
+> [Check out this replay](https://replay.help/playwright-flake-debug) for a detailed walkthrough on debugging a flaky Playwright test.
 
-Replay is designed to record tests in CI so you can debug when tests fail. Without Replay, test failures in CI are like a black box, with little insights into what went wrong. By recording with Replay, you get a full recording of the test run with debugging tools built in.
+## Record your tests in CI
 
-Here are basic configurations for some of the most popular providers which you can add to you project
-
-## Done!
-
-You’re ready to inspect your local test run in Replay DevTools now. You can also record your tests in your CI environment. Learn how to set up Replay with your Cypress tests on [GitHub Actions](/test-runners/playwright/github-actions) and [other CI providers](/test-runners/playwright/other-ci-providers).
+Now that you're ready to inspect your local tests, the next step is to record your tests in CI. Learn how to set up Replay with your Playwright tests on [GitHub Actions](/test-runners/playwright/github-actions) and [other CI providers](/test-runners/playwright/other-ci-providers).
 
 {% /steps %}
-
-{% callout type="replay" %}
-[Check out this replay](https://replay.help/playwright-flake-debug) for a detailed walkthrough on debugging a flaky Playwright test. You'll see the capabilities of Replay DevTools and walk through the debugging process of identifying the root cause.
-{% /callout %}
 
 {% quick-links title="Read more" description="Learn how to record your tests, manage your test suite and debug flaky tests using Replay DevTools" %}
 


### PR DESCRIPTION
This fixes a couple of things

1. It removes the CI section which should not be shown until you've finished getting setup locally
2. Changes done to "Record your test locally" and fixes the copy. For example we still said Cypress there
3. Moves the view replay callout to below the record your test section. Note we should also link to a replay that we just recorded which in this case looks like todos. basically we should choose one example!


### Old
<img width="855" alt="Screenshot 2024-05-25 at 9 29 40 AM" src="https://github.com/replayio/docs/assets/254562/ac6c1bc5-bc15-4fbc-832b-225115639b13">
<img width="870" alt="Screenshot 2024-05-25 at 9 29 35 AM" src="https://github.com/replayio/docs/assets/254562/adfa55f0-691b-4cd6-9ee6-6ecf6705ef99">
<img width="867" alt="Screenshot 2024-05-25 at 9 29 30 AM" src="https://github.com/replayio/docs/assets/254562/8dd8f2d2-24fe-4948-a0ab-1e24eafe193e">

### New
<img width="800" alt="Screenshot 2024-05-25 at 9 29 47 AM" src="https://github.com/replayio/docs/assets/254562/16ceaf28-845e-4669-9bd4-071d62bae37e">
<img width="879" alt="Screenshot 2024-05-25 at 9 29 52 AM" src="https://github.com/replayio/docs/assets/254562/1399dfa2-74fa-46f0-9093-4007ca26740c">
