### PR TITLE
Trim Playwright setup instructions

### DIFF
--- a/src/app/basics/getting-started/record-your-playwright-tests/page.md
+++ b/src/app/basics/getting-started/record-your-playwright-tests/page.md
@@ -2,12 +2,9 @@
 title: Record your Playwright tests
 ---
 
-{% steps %}
+Recording your tests with Replay is easy. All you need to do is create a test team and update your Playwright config to use Replay's Playwright reporter.
 
-## Create a new testsuite team
-
-Start by visiting our [new testsuite form](https://app.replay.io/team/new/tests).
-It will create an API key and guide you through each step.
+[Click here](https://app.replay.io/team/new/tests) to open our test setup guide and get started.
 
 {% figure
     alt="Jumping to code"
@@ -16,124 +13,9 @@ It will create an API key and guide you through each step.
     width=870
 /%}
 
-## Install the Playwright Plugin package into your project
+Once you've updated your Playwright config, the next step is to [record your tests in CI](/reference/test-runners/playwright/github-actions).
 
-{% tabs labels=["npm", "yarn", "pnpm", "bun"] %}
-{% tab %}
-
-```sh
-npm install @replayio/playwright -D
-```
-
-{% /tab %}
-{% tab %}
-
-```sh
-yarn add @replayio/playwright -D
-```
-
-{% /tab %}
-{% tab %}
-
-```sh
-pnpm install @replayio/playwright -D
-```
-
-{% /tab %}
-{% tab %}
-
-```sh
-bun install @replayio/playwright -D
-```
-
-{% /tab %}
-{% /tabs %}
-
-## Save your API key
-
-To use your API key, you can either use [dotenv package](https://www.npmjs.com/package/dotenv) and save it to a `.env` file or add the API key to your environment directly.
-
-{% tabs labels=[".env", "macOS/Linux", "Windows"] %}
-{% tab %}
-
-```bash {% fileName=".env" %}
-REPLAY_API_KEY=<your_api_key>
-```
-
-{% /tab %}
-{% tab %}
-
-```sh
-export REPLAY_API_KEY=<your_api_key>
-```
-
-{% /tab %}
-{% tab %}
-
-```sh
-set REPLAY_API_KEY=<your_api_key>
-```
-
-{% /tab %}
-{% /tabs %}
-
-## Update your configuration
-
-```js {% fileName="playwright.config.ts" highlight=[2, "7-10","14-17"] lineNumbers=true %}
-import { PlaywrightTestConfig, devices } from "@playwright/test";
-import { devices as replayDevices, replayReporter } from "@replayio/playwright";
-import "dotenv/config";
-
-const config: PlaywrightTestConfig = {
-  reporter: [
-    replayReporter({
-      apiKey: process.env.REPLAY_API_KEY,
-      upload: true,
-    }),
-    ["line"],
-  ],
-  projects: [
-    {
-      name: "replay-chromium",
-      use: { ...replayDevices["Replay Chromium"] },
-    },
-  ],
-};
-export default config;
-```
-
-## Record your test
-
-Once you have added Chromium Replay Browser to your project, you are ready to create your recordings. You can run your tests normally, using `npx playwright test` command.
-
-If your project has multiple browsers set up, you can run Replay Browser only:
-
-```sh
-npx playwright test --project replay-chromium
-```
-
-```sh
-➜ npx playwright test
-
-Running 1 test using 1 worker
-[1/1] things-app.spec.ts:14:7 › Todos › should allow me to add todo items
-[replay.io]: 🕑 Completing some outstanding work ...
-[replay.io]:
-[replay.io]: 🚀 Successfully uploaded 1 recordings:
-[replay.io]:
-[replay.io]:    ✅ should allow me to add todo items
-  1 passed (2.1s)
-```
-
-> [Check out this replay](https://replay.help/playwright-flake-debug) for a detailed walkthrough on debugging a flaky Playwright test.
-
-## Record your tests in CI
-
-Now that you're ready to inspect your local tests, the next step is to record your tests in CI. Learn how to set up Replay with your Playwright tests on [GitHub Actions](/reference/test-runners/playwright/github-actions) and [other CI providers](/reference/test-runners/playwright/other-ci-providers).
-
-{% /steps %}
-
-{% quick-links title="Read more" description="Learn how to record your tests, manage your test suite and debug flaky tests using Replay DevTools" %}
+{% quick-links title="Read more" description="" %}
 
 {% quick-link
   title="Record Your CI Test Run"

--- a/src/components/QuickLinks.tsx
+++ b/src/components/QuickLinks.tsx
@@ -1,6 +1,6 @@
-import Link from 'next/link'
-
 import { Icon } from '@/components/Icon'
+import Link from 'next/link'
+import { ReactNode } from 'react'
 
 export function QuickLinks({
   children,
@@ -10,11 +10,16 @@ export function QuickLinks({
 }: {
   children: React.ReactNode
   title: string
-  description: string
+  description: ReactNode
   mini?: boolean
 }) {
+  let className
+  if (description || title) {
+    className = mini ? 'mt-12' : 'mt-12 rounded-xl py-8'
+  }
+
   return (
-    <div className={mini ? 'mt-12' : 'mt-12 rounded-xl py-8 '}>
+    <div className={className}>
       {title && (
         <div className="text-2xl font-medium text-gray-800 dark:text-gray-100">
           {title}

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -55,5 +55,5 @@ export default {
   Steps,
   TwoColumns,
   Group,
-  SnapshotsVsReplay
+  SnapshotsVsReplay,
 }

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -24,11 +24,11 @@ export const navigation: Record<NavigationNames, NavigationItem[]> = {
           href: '/basics/getting-started/record-your-app',
         },
         {
-          title: 'Record your Cypress.io test',
+          title: 'Record your Cypress.io tests',
           href: '/basics/getting-started/record-your-cypress-tests',
         },
         {
-          title: 'Record your Playwright test',
+          title: 'Record your Playwright tests',
           href: '/basics/getting-started/record-your-playwright-tests',
         },
       ],


### PR DESCRIPTION
This is kind of a hot take but as I think about our Playwright setup docs, I keep coming back around to the fact that I don't think we should duplicate the setup form on our docs– at least not the quick start docs we show you right away, because it buries our calls to action (the "record your test in CI") too far down the page.

Maybe we could add an "advanced" section somewhere, but that's awkward too because the literal first step will be to go to the test setup form and create a team (which will then walk you through the rest of the steps).

Anyway I think our Playwright quick start guide _could be_ as succinct as this:

![Screenshot 2024-05-28 at 5 18 49 PM](https://github.com/replayio/docs/assets/29597/4fecd30f-a263-4eb8-8271-99cd8bf3adfa)

Note that I'm not married to the specific wording. The main pitch here is to trim the current content way down.