### PR TITLE
Fix incorrect spelling

### DIFF
--- a/src/app/basics/getting-started/record-your-playwright-tests/page.md
+++ b/src/app/basics/getting-started/record-your-playwright-tests/page.md
@@ -4,9 +4,9 @@ title: Record your Playwright tests
 
 {% steps %}
 
-## Create a new testsuite team
+## Create a new test suite team
 
-Start by visiting our [new testsuite form](https://app.replay.io/team/new/tests).
+Start by visiting our [new test suite form](https://app.replay.io/team/new/tests).
 It will create an API key and guide you through each step.
 
 {% figure


### PR DESCRIPTION
We say "test suite" everywhere else _except_ the first page you see the term, where we say "testsuite". This PR fixes that.