### PR TITLE
Cleaning up copy on Replay Firefox page

### DIFF
--- a/src/app/reference/replay-runtimes/replay-firefox/page.md
+++ b/src/app/reference/replay-runtimes/replay-firefox/page.md
@@ -1,12 +1,11 @@
 ---
 title: Replay Firefox
 description: Replay Firefox is a standalone browser with a record button that lets you capture your web application and share the replay with others.
-image: /images/firefox.png
 ---
 
-## Overview
+## Replay Firefox has been deprecated
 
-Replay Firefox was our first runtime, so it’ll always have a special place in our hearts, but because Chrome has such a significant market share and browser tests that pass reliably on Chrome, fail intermittently in Firefox, we decided in 2023 that we had to bet on Chrome and sadly stop maintaining Replay Firefox for the time being.
+Replay Firefox was our first runtime, so it’ll always have a special place in our hearts. Unfortunately, because Chrome has such a significant market share, we decided in 2023 that we had to bet on Chrome and stop maintaining Replay Firefox.
 
 ### Use Cases
 
@@ -14,7 +13,7 @@ Even though Replay Firefox is currently deprecated, it will continue to be avail
 
 1.  Downloading a standalone browser for recording bug reports.
 
-2.  Recording bug reports on Windows. Replay Firefox Windows has a 40% replay crash rate, so we only recommend trying it if you’re okay putting up with the reliability issues
+2.  Recording bug reports on Windows. Replay Firefox Windows has a 40% replay crash rate, so we only recommend trying it if you’re okay putting up with reliability issues.
 
 ### Download links
 


### PR DESCRIPTION
We had a massive run-on sentence, an image that didn't need to be there, and a generic header. We need to get to the point, which is "this is deprecated." This is especially important because it's such a fundamental part of our tech support. We send lots of people here.