### PR TITLE
fix misc. typos

### DIFF
--- a/src/app/basics/test-suites/overview/page.md
+++ b/src/app/basics/test-suites/overview/page.md
@@ -56,7 +56,7 @@ Because of this, a flaky test does not feel like an act of higher force, but can
 
 Replay Devtools work great with your existing test suite. Cypress and Playwright plugins allow you to **rewind or fast forward** to any command from your test run.
 
-The command details panel contains information on passed arguments, returned values and targeted element. Commands are integrated with the rest of DevTools. This means you can jump from a command detail into [Elements panel](/basics/replay-devtools/browser-devtools/elements-panel), or inspect API calls in the [Network panel](/basics/replay-devtools/browser-devtools/network-monitor).
+The command details panel contains information on passed arguments, returned values, and targeted elements. Commands are integrated with the rest of DevTools. This means you can jump from a command detail into the [Elements panel](/basics/replay-devtools/browser-devtools/elements-panel), or inspect API calls in the [Network panel](/basics/replay-devtools/browser-devtools/network-monitor).
 {% /basic %}
 
 {% video src="elementsPanelStopWatch" /%}
@@ -153,7 +153,7 @@ There are a [couple of strategies](/reference/ci-workflows/recording-strategies)
 
 When a test fails on CI, you don’t need to replicate it locally anymore. A recording captures your test run **exactly** as it happened and will provide you better insight than if you tried to locally reproduce an issue from CI.
 
-If you battle with flaky tests, you can [compare a failing and a passing test](https://replay.help/playwright-flake-debug) to detect the difference. This can be caused by inconsistent data, race condition, test running too fast, or any other reason. What’s important is that the reason will no longer be a mystery, because Replay Browser records your test steps, your app, and everything in between. If you were able to capture the test flake, you’ll be able to debug it. Soon, we’ll be able to [help you find the root cause](/basics/test-suites/root-cause-analysis).
+If you battle with flaky tests, you can [compare a failing and a passing test](https://replay.help/playwright-flake-debug) to detect the difference. This can be caused by inconsistent data, race condition, the test running too fast, or any other reason. What’s important is that the reason will no longer be a mystery, because Replay Browser records your test steps, your app, and everything in between. If you were able to capture the test flake, you’ll be able to debug it. Soon, we’ll be able to [help you find the root cause](/basics/test-suites/root-cause-analysis).
 
 {% /accordion-item %}
 


### PR DESCRIPTION
I found these while doing an onboarding audit:

https://www.notion.so/replayio/Miriam-next-js-onboarding-685cff62f032467bab8f1d6085a33544?showMoveTo=true&saveParent=true