### PR TITLE
Edit `src/app/basics/getting-started/record-your-app/page.md`

### DIFF
--- a/src/app/basics/getting-started/record-your-app/page.md
+++ b/src/app/basics/getting-started/record-your-app/page.md
@@ -106,10 +106,10 @@ Replays need to be uploaded so the browser can be replayed in the Replay Cloud. 
 {% quick-links title="Next Steps"  %}
 
 {% quick-link
-  title="Inspect your replay"
+  title="Inspect our replay"
   icon="console"
   href="/basics/getting-started/inspect-replay"
-  description="Walk through the steps of inspecting your new replay."
+  description="Walk through the steps of inspecting our new replay."
 /%}
 
 {% quick-link

--- a/src/app/basics/getting-started/record-your-app/page.md
+++ b/src/app/basics/getting-started/record-your-app/page.md
@@ -1,5 +1,5 @@
 ---
-title: Record your app
+title: Record your application
 ---
 
 Recording your application with the Replay browser lets you capture a bug once and inspect it after the fact without having to reproduce it again. This makes it possible to:
@@ -63,7 +63,7 @@ This command:
 
 ## Inspect your recording
 
-When you close the browser, you'll be prompted to upload your recordings. Once the upload is completed, you will get a URL where you can inspect your app with Replay DevTools.
+When you close the browser, you'll be prompted to upload your recordings. Once the upload is completed, you will get a URL where you can inspect your application with Replay DevTools.
 
 ```sh
 Uploading recordings...

--- a/src/app/basics/getting-started/record-your-app/page.md
+++ b/src/app/basics/getting-started/record-your-app/page.md
@@ -5,10 +5,10 @@ title: Record your app
 Recording your application with the Replay browser lets you capture a bug once and inspect it after the fact without having to reproduce it again. This makes it possible to:
 
 - [Share the replay as a URL with your team so others can inspect it as if they were there when you recorded it.](/basics/replay-devtools/time-travel-devtools/collaborative-devtools)
-- [Debug the replay with `console.log` added in at any point of the recording.](/basics/replay-devtools/time-travel-devtools/live-console-logs)
+- [Debug the replay by adding new `console.log` statements anywhere in the recording.](/basics/replay-devtools/time-travel-devtools/live-console-logs)
 - [Inspect Network requests](/basics/replay-devtools/browser-devtools/network-monitor), [React components](/basics/replay-devtools/framework-devtools/react-panel), and [DOM elements](/basics/replay-devtools/browser-devtools/elements-panel) as if the application were running live on your laptop.
 
-In this guide, we'll use the Replay CLI to record first.replay.io. If you'd like to record your Playwright or Cypress tests, feel free to [jump ahead](/reference/test-runners/overview).
+In this guide, we'll use the Replay CLI to record the website https://first.replay.io/. If you'd like to record your Playwright or Cypress tests, feel free to [jump ahead](/reference/test-runners/overview).
 
 {% steps %}
 
@@ -52,18 +52,18 @@ bun i -g replayio
 Run the following command to open the Replay browser and start recording.
 
 ```sh
-replayio record first.replay.io/
+replayio record https://first.replay.io/
 ```
 
 This command will:
 
 - Prompt you to login to your Replay account with Google (if not already logged in)
 - Install the Replay browser (if not already installed)
-- Open the Replay browser to begin recording `first.replay.io`
+- Open the Replay browser to begin recording `https://first.replay.io/`
 
-## Inspect your replay
+## Inspect your recording
 
-When you close the browser, you'll be prompted to upload your recordings. Once the upload is completed, you will get a url where you can inspect your app with Replay DevTools.
+When you close the browser, you'll be prompted to upload your recordings. Once the upload is completed, you will get a URL where you can inspect your app with Replay DevTools.
 
 ```sh
 Uploading recordings...
@@ -73,7 +73,7 @@ View recording at:
 https://app.replay.io/recording/a616009e-b825-4c54-83b4-e20bd8c0cb25
 ```
 
-Now that we've recorded our first [replay](https://app.replay.io/recording/a616009e-b825-4c54-83b4-e20bd8c0cb25), lets look at what it looks like to [inspect it with Replay DevTools](/basics/getting-started/inspect-replay).
+Now that we've recorded our first [replay](https://app.replay.io/recording/a616009e-b825-4c54-83b4-e20bd8c0cb25), let's [inspect it with Replay DevTools](/basics/getting-started/inspect-replay).
 
 {% /steps %}
 
@@ -97,7 +97,7 @@ In the interim, if you would perfer downloading a browser directly, you can use 
 
 {% accordion-item title="Why do I need to login to Replay?" %}
 
-Replays need to be uploaded so that the browser can be replayed in the Replay Cloud. [How time travel works](/basics/time-travel/how-does-time-travel-work)
+Recordings need to be uploaded so the browser can be replayed in the Replay Cloud. See [How time travel works](/basics/time-travel/how-does-time-travel-work) for more information.
 
 {% /accordion-item %}
 
@@ -106,7 +106,7 @@ Replays need to be uploaded so that the browser can be replayed in the Replay Cl
 {% quick-links title="Next Steps"  %}
 
 {% quick-link
-  title="Inspect our replay"
+  title="Inspect your first recording"
   icon="console"
   href="/basics/getting-started/inspect-replay"
   description="Walk through the steps of inspecting our new replay."
@@ -120,7 +120,7 @@ Replays need to be uploaded so that the browser can be replayed in the Replay Cl
 /%}
 
 {% quick-link
-  title="Setup a team"
+  title="Set up a team"
   icon="settingupateam"
   href="/basics/replay-teams/setting-up-a-team"
   description="Learn how to share replays as a team."

--- a/src/app/basics/getting-started/record-your-app/page.md
+++ b/src/app/basics/getting-started/record-your-app/page.md
@@ -55,11 +55,11 @@ Run the following command to open the Replay browser and start recording.
 replayio record https://first.replay.io/
 ```
 
-This command will:
+This command:
 
-- Prompt you to login to your Replay account with Google (if not already logged in)
-- Install the Replay browser (if not already installed)
-- Open the Replay browser to begin recording `https://first.replay.io/`
+- Prompts you to log in to your Replay account with Google (if not already logged in)
+- Installs the Replay browser (if not already installed)
+- Opens the Replay browser to begin recording `https://first.replay.io/`
 
 ## Inspect your recording
 

--- a/src/app/basics/getting-started/record-your-app/page.md
+++ b/src/app/basics/getting-started/record-your-app/page.md
@@ -61,7 +61,7 @@ This command:
 - Installs the Replay browser (if not already installed)
 - Opens the Replay browser to begin recording `https://first.replay.io`
 
-## Inspect your recording
+## Inspect your replay
 
 When you close the browser, you'll be prompted to upload your recordings. Once the upload is completed, you will get a URL where you can inspect your application with Replay DevTools.
 
@@ -97,7 +97,7 @@ In the interim, if you would perfer downloading a browser directly, you can use 
 
 {% accordion-item title="Why do I need to login to Replay?" %}
 
-Recordings need to be uploaded so the browser can be replayed in the Replay Cloud. See [How time travel works](/basics/time-travel/how-does-time-travel-work) for more information.
+Replays need to be uploaded so the browser can be replayed in the Replay Cloud. See [How time travel works](/basics/time-travel/how-does-time-travel-work) for more information.
 
 {% /accordion-item %}
 
@@ -106,10 +106,10 @@ Recordings need to be uploaded so the browser can be replayed in the Replay Clou
 {% quick-links title="Next Steps"  %}
 
 {% quick-link
-  title="Inspect your first recording"
+  title="Inspect your replay"
   icon="console"
   href="/basics/getting-started/inspect-replay"
-  description="Walk through the steps of inspecting our new replay."
+  description="Walk through the steps of inspecting your new replay."
 /%}
 
 {% quick-link

--- a/src/app/basics/getting-started/record-your-app/page.md
+++ b/src/app/basics/getting-started/record-your-app/page.md
@@ -106,10 +106,10 @@ Replays need to be uploaded so the browser can be replayed in the Replay Cloud. 
 {% quick-links title="Next Steps"  %}
 
 {% quick-link
-  title="Inspect our replay"
+  title="Inspect your replay"
   icon="console"
   href="/basics/getting-started/inspect-replay"
-  description="Walk through the steps of inspecting our new replay."
+  description="Walk through the steps of inspecting your new replay."
 /%}
 
 {% quick-link

--- a/src/app/basics/getting-started/record-your-app/page.md
+++ b/src/app/basics/getting-started/record-your-app/page.md
@@ -5,10 +5,10 @@ title: Record your app
 Recording your application with the Replay browser lets you capture a bug once and inspect it after the fact without having to reproduce it again. This makes it possible to:
 
 - [Share the replay as a URL with your team so others can inspect it as if they were there when you recorded it.](/basics/replay-devtools/time-travel-devtools/collaborative-devtools)
-- [Debug the replay by adding new `console.log` statements anywhere in the recording.](/basics/replay-devtools/time-travel-devtools/live-console-logs)
+- [Debug your application by adding new `console.log` statements anywhere in the recording.](/basics/replay-devtools/time-travel-devtools/live-console-logs)
 - [Inspect Network requests](/basics/replay-devtools/browser-devtools/network-monitor), [React components](/basics/replay-devtools/framework-devtools/react-panel), and [DOM elements](/basics/replay-devtools/browser-devtools/elements-panel) as if the application were running live on your laptop.
 
-In this guide, we'll use the Replay CLI to record the website https://first.replay.io/. If you'd like to record your Playwright or Cypress tests, feel free to [jump ahead](/reference/test-runners/overview).
+In this guide, we'll use the Replay CLI to record your interactions on the page https://first.replay.io/. If you'd like to record your Playwright or Cypress tests instead, feel free to [jump ahead](/reference/test-runners/overview).
 
 {% steps %}
 

--- a/src/app/basics/getting-started/record-your-app/page.md
+++ b/src/app/basics/getting-started/record-your-app/page.md
@@ -8,7 +8,7 @@ Recording your application with the Replay browser lets you capture a bug once a
 - [Debug your application by adding new `console.log` statements anywhere in the recording.](/basics/replay-devtools/time-travel-devtools/live-console-logs)
 - [Inspect Network requests](/basics/replay-devtools/browser-devtools/network-monitor), [React components](/basics/replay-devtools/framework-devtools/react-panel), and [DOM elements](/basics/replay-devtools/browser-devtools/elements-panel) as if the application were running live on your laptop.
 
-In this guide, we'll use the Replay CLI to record your interactions on the page https://first.replay.io/. If you'd like to record your Playwright or Cypress tests instead, feel free to [jump ahead](/reference/test-runners/overview).
+In this guide, we'll use the Replay CLI to record your interactions on the page `https://first.replay.io`. If you'd like to record your Playwright or Cypress tests instead, feel free to [jump ahead](/reference/test-runners/overview).
 
 {% steps %}
 
@@ -52,14 +52,14 @@ bun i -g replayio
 Run the following command to open the Replay browser and start recording.
 
 ```sh
-replayio record https://first.replay.io/
+replayio record https://first.replay.io
 ```
 
 This command:
 
 - Prompts you to log in to your Replay account with Google (if not already logged in)
 - Installs the Replay browser (if not already installed)
-- Opens the Replay browser to begin recording `https://first.replay.io/`
+- Opens the Replay browser to begin recording `https://first.replay.io`
 
 ## Inspect your recording
 

--- a/tests/toc.spec.ts
+++ b/tests/toc.spec.ts
@@ -4,7 +4,7 @@ test('table of contents redirects to proper item', async ({ page }) => {
   await page.goto('/basics/getting-started/record-your-app')
 
   const toc = page.locator('[data-testid="table-of-contents"]')
-  await toc.getByText('Inspect your recording').click()
+  await toc.getByText('Inspect your replay').click()
   await expect(page).toHaveURL(/.*\/record-your-app#inspect-your-replay/)
 
   const article = page.locator('article')

--- a/tests/toc.spec.ts
+++ b/tests/toc.spec.ts
@@ -4,7 +4,7 @@ test('table of contents redirects to proper item', async ({ page }) => {
   await page.goto('/basics/getting-started/record-your-app')
 
   const toc = page.locator('[data-testid="table-of-contents"]')
-  await toc.getByText('Inspect your replay').click()
+  await toc.getByText('Inspect your recording').click()
   await expect(page).toHaveURL(/.*\/record-your-app#inspect-your-replay/)
 
   const article = page.locator('article')

--- a/tests/toc.spec.ts
+++ b/tests/toc.spec.ts
@@ -7,7 +7,8 @@ test('table of contents redirects to proper item', async ({ page }) => {
   await toc.getByText('Inspect your replay').click()
   await expect(page).toHaveURL(/.*\/record-your-app#inspect-your-replay/)
 
-  const article = page.locator('article')
-  const heading = article.getByText('Inspect your replay')
+  const heading = page
+    .getByRole('link', { name: 'Inspect your replay' })
+    .first()
   await expect(heading).toBeVisible()
 })


### PR DESCRIPTION
Consistency changes:

- Instances of "app" changed to "application"
- Changed line to "Debug your application by adding new `console.log` statements anywhere in the recording." to make it clearer how we differ from session replay.
- Replaced "first.replay.io" with a formatted URL. Janelle found this ambiguous and I agree. We should ruthlessly remove inconsistencies and ambiguities.
- Changed the imperative tense to simple present indicative in the section that explains what the command does. I did this because if the reader skipped reading "This command will:", the list looked like a list of instructions, not a description of what _will_ happen automatically when the user runs a command.
- Replaced instances of "replay" to refer to a recording with "recording". We were using both, but we use "recording" more. I think this is much clearer to new users, and even to me.