### PR TITLE
Changing "recording" to "replay" in several places

### DIFF
--- a/src/app/basics/getting-started/inspect-replay/page.md
+++ b/src/app/basics/getting-started/inspect-replay/page.md
@@ -1,6 +1,6 @@
 ---
 title: Inspect your replay
-description: Once your recording is uploaded, you can inspect it with Replay DevTools.
+description: Once your replay is uploaded, you can inspect it with Replay DevTools.
 image: /images/recording_landing_page.png
 ---
 
@@ -12,7 +12,7 @@ By default, you're set to "Viewer" mode. You can change the view to "DevTools" m
 
 ## Jump to an event
 
-Let's jump to the last "Click" before the recording hit an error and see the code related to it:
+Let's jump to the last "Click" before the replay hit an error and see the code related to it:
 
 {% video src="devtoolsClickToEvent" /%}
 

--- a/src/app/basics/getting-started/record-your-app/page.md
+++ b/src/app/basics/getting-started/record-your-app/page.md
@@ -5,7 +5,7 @@ title: Record your application
 Recording your application with the Replay browser lets you capture a bug once and inspect it after the fact without having to reproduce it again. This makes it possible to:
 
 - [Share the replay as a URL with your team so others can inspect it as if they were there when you recorded it.](/basics/replay-devtools/time-travel-devtools/collaborative-devtools)
-- [Debug your application by adding new `console.log` statements anywhere in the recording.](/basics/replay-devtools/time-travel-devtools/live-console-logs)
+- [Debug your application by adding new `console.log` statements anywhere in the replay.](/basics/replay-devtools/time-travel-devtools/live-console-logs)
 - [Inspect Network requests](/basics/replay-devtools/browser-devtools/network-monitor), [React components](/basics/replay-devtools/framework-devtools/react-panel), and [DOM elements](/basics/replay-devtools/browser-devtools/elements-panel) as if the application were running live on your laptop.
 
 In this guide, we'll use the Replay CLI to record your interactions on the page `https://first.replay.io`. If you'd like to record your Playwright or Cypress tests instead, feel free to [jump ahead](/reference/test-runners/overview).
@@ -81,9 +81,9 @@ Now that we've recorded our first [replay](https://app.replay.io/recording/a6160
 
 {% accordion %}
 
-{% accordion-item title="How do I upload recordings later?" %}
+{% accordion-item title="How do I upload replays later?" %}
 
-You can always upload recordings later via the `replayio upload` command. Read more in Replay CLI [docs](/reference/replay-cli/commands).
+You can always upload replays later via the `replayio upload` command. Read more in Replay CLI [docs](/reference/replay-cli/commands).
 
 {% /accordion-item %}
 
@@ -91,11 +91,11 @@ You can always upload recordings later via the `replayio upload` command. Read m
 
 We are excited to release the Replay browser as a standalone application that you can download directly, log into, and start recording in a couple of months.
 
-In the interim, if you would perfer downloading a browser directly, you can use the [Replay Firefox](/reference/replay-runtimes/replay-firefox) browser.
+In the interim, if you would prefer downloading a browser directly, you can use the [Replay Firefox](/reference/replay-runtimes/replay-firefox) browser.
 
 {% /accordion-item %}
 
-{% accordion-item title="Why do I need to login to Replay?" %}
+{% accordion-item title="Why do I need to log in to Replay?" %}
 
 Replays need to be uploaded so the browser can be replayed in the Replay Cloud. See [How time travel works](/basics/time-travel/how-does-time-travel-work) for more information.
 

--- a/src/app/basics/replay-devtools/browser-devtools/console/page.md
+++ b/src/app/basics/replay-devtools/browser-devtools/console/page.md
@@ -55,7 +55,7 @@ This is one of the most egregious cases where browser DevTools will lie to you a
 
 A powerful way to bisect a difficult problem down to the root cause is to set the [focus window](/basics/replay-devtools/time-travel-devtools/focus-window) start or end to a console message.
 
-Setting the focus window will limit the execution range in the recording which will hide the messages and other events that are outside of the window and let you progressively zero in on the root cause.
+Setting the focus window will limit the execution range in the replay which will hide the messages and other events that are outside of the window and let you progressively zero in on the root cause.
 
 ### View JS event handlers
 

--- a/src/app/basics/replay-devtools/browser-devtools/pause-panel/page.md
+++ b/src/app/basics/replay-devtools/browser-devtools/pause-panel/page.md
@@ -27,11 +27,11 @@ Traditional debuggers let you pause at breakpoints, resume, step forward, in, an
 
 ### Breakpoints
 
-The breakpoints pane helps you manage the breakpoints you’ve set in the recording and see the breakpoints that others have set as well.
+The breakpoints pane helps you manage the breakpoints you’ve set in the replay and see the breakpoints that others have set as well.
 
 ### Print statements
 
-The print statements pane helps you manage the console logs you’ve set in the recording and see the console logs that others have set as well.
+The print statements pane helps you manage the console logs you’ve set in the replay and see the console logs that others have set as well.
 
 ## Time Travel
 

--- a/src/app/basics/replay-devtools/browser-devtools/source-viewer/page.md
+++ b/src/app/basics/replay-devtools/browser-devtools/source-viewer/page.md
@@ -25,9 +25,9 @@ Press `cmd+shift+o` or open the Source panel in the right toolbar, to view the f
 
 ### Source explorer
 
-Press `cmd+p` or open the Source explorer in the right toolbar, to view the sources that were loaded in the recording.
+Press `cmd+p` or open the Source explorer in the right toolbar, to view the sources that were loaded in the replay.
 
-Note that because recordings can span multiple navigations and include source maps, the sources you’re viewing will include original files and could be included in multiple pages.
+Note that because replays can span multiple navigations and include source maps, the sources you’re viewing will include original files and could be included in multiple pages.
 
 ### Jump to generated location
 

--- a/src/app/basics/replay-devtools/framework-devtools/react-panel/page.md
+++ b/src/app/basics/replay-devtools/framework-devtools/react-panel/page.md
@@ -37,7 +37,7 @@ Because we’re able to compare the current component’s render with the prior,
 
 ### View hook values
 
-Because we’re able to collect more information at while replaying the recording, we’re able to stop showing the hook index and start showing the hook value and function definition.
+Because we’re able to collect more information at while replaying the replay, we’re able to stop showing the hook index and start showing the hook value and function definition.
 
 ### Mapped component names
 

--- a/src/app/basics/replay-devtools/framework-devtools/redux-panel/page.md
+++ b/src/app/basics/replay-devtools/framework-devtools/redux-panel/page.md
@@ -11,7 +11,7 @@ The Redux panel has all of the features you’ve come to expect to find in Redux
 
 ### Actions
 
-- View the actions that were dispatched during the recording and jump to the point in time they were dispatched.
+- View the actions that were dispatched during the replay and jump to the point in time they were dispatched.
 - Filter the actions list by name
 - Inspect the action payload
 - Inspect the application state after each dispatch

--- a/src/app/basics/replay-devtools/time-travel-devtools/live-console-logs/page.md
+++ b/src/app/basics/replay-devtools/time-travel-devtools/live-console-logs/page.md
@@ -8,7 +8,7 @@ Our goal with Replay is to design the best environment for helping you think thr
 
 This starts with the feedback loop you can achieve adding console logs in Replay. Simply click on a line of code, add an expression, press enter, and see the messages appear in the Console as if it’s always been there.
 
-Under the hood, this works because when you add a console log in Replay, there’s a browser in the cloud that runs through the recording, pauses at each execution point, evaluates the expression, and resumes. But as a user, all you have to think about is what questions you’d like to answer.
+Under the hood, this works because when you add a console log in Replay, there’s a browser in the cloud that runs through the replay, pauses at each execution point, evaluates the expression, and resumes. But as a user, all you have to think about is what questions you’d like to answer.
 
 {% video src="consoleLogs" /%}
 

--- a/src/app/basics/replay-devtools/time-travel-devtools/timeline-annotation/page.md
+++ b/src/app/basics/replay-devtools/time-travel-devtools/timeline-annotation/page.md
@@ -53,9 +53,10 @@ When text comments are not enough to share what you’re seeing, it can be helpf
 With sharable URLs and embed previews for Twitter, Slack, and Discord, replays are designed to be shared. The URLs will include the execution point you’re currently paused at and other relevant context as well.
 
 {% callout title="Coming soon" showIcon=false %}
+
 ## Include expressions
 
-Expressions will let you include expressions that you’ve evaluated at the comment’s execution point so that you can see their values at that point in time and see how they changed over the course of the recording.
+Expressions will let you include expressions that you’ve evaluated at the comment’s execution point so that you can see their values at that point in time and see how they changed over the course of the replay.
 
 ## Linear and Jira integrations
 

--- a/src/app/basics/replay-teams/billing/page.md
+++ b/src/app/basics/replay-teams/billing/page.md
@@ -37,12 +37,12 @@ Our plan details are at replay.io/pricing.
 If more than 10 people from your team use Replay, then an Organization or Enterprise plan is the recommended plan. See Premium Features for more details.
 
 {% callout emoji="🏉" title=""%}
-Org + Enterprise plans include added features like SSO integration, more configurability of user settings, libraries, and higher limits for recordings and API keys.
+Org + Enterprise plans include added features like SSO integration, more configurability of user settings, libraries, and higher limits for replays and API keys.
 {% /callout%}
 
 ### What is the maximum number of users on Team Plan?
 
-You can have up to 10 users total (Developers + Users) on the Team plan. We charge based on Developer seats. Any Replay User can make a recording for the Team.
+You can have up to 10 users total (Developers + Users) on the Team plan. We charge based on Developer seats. Any Replay User can make a replay for the Team.
 
 ### What are the differences between a Developer and a User role?
 

--- a/src/app/basics/replay-teams/enterprise-security-controls/page.md
+++ b/src/app/basics/replay-teams/enterprise-security-controls/page.md
@@ -8,13 +8,13 @@ It’s possible to host your Replay data in the S3 Bucket or storage of your cho
 
 ### URL Allowlist and Blocklist
 
-It’s possible to specify a set of URLs which can be included or excluded from a Replay. This gives you control to limit Replay recordings to web apps that are hosted on certain URLs or to environments that belong to match domains.
+It’s possible to specify a set of URLs which can be included or excluded from a Replay. This gives you control to limit replays to web apps that are hosted on certain URLs or to environments that belong to match domains.
 
 Examples
 
-- Allow recordings for development and staging, exclude production
+- Allow replays for development and staging, exclude production
 
-- Allow recordings for `/search` exclude recordings which match `/checkout`
+- Allow replays for `/search` exclude replays which match `/checkout`
 
 ## SSO Integrations
 

--- a/src/app/basics/test-suites/overview/page.md
+++ b/src/app/basics/test-suites/overview/page.md
@@ -6,7 +6,7 @@ description: Capture flakes in CI. Investigate failures with browser DevTools. A
 
 ## Using Replay with your test suite
 
-You can use Replay for your test suite is a drop-in replacement for the browser you currently use when running your end-to-end tests. By doing so, your tests can be debugged using [Replay's time travel.](/basics/time-travel/why-time-travel) 
+You can use Replay for your test suite is a drop-in replacement for the browser you currently use when running your end-to-end tests. By doing so, your tests can be debugged using [Replay's time travel.](/basics/time-travel/why-time-travel)
 
 Whether you use Playwright, Cypress, or other test runners, you simply swap your current browser with **Replay Browser** and that’s it:
 
@@ -151,7 +151,7 @@ At the first glance, that recording may look like a series of snapshots of your 
 
 There are a [couple of strategies](/reference/ci-workflows/recording-strategies) you can adopt, but generally you can use Replay Browser with every test run on your CI, as there is both short-term and long-term value.
 
-When a test fails on CI, you don’t need to replicate it locally anymore. A recording captures your test run **exactly** as it happened and will provide you better insight than if you tried to locally reproduce an issue from CI.
+When a test fails on CI, you don’t need to replicate it locally anymore. A replay captures your test run **exactly** as it happened and will provide you better insight than if you tried to locally reproduce an issue from CI.
 
 If you battle with flaky tests, you can [compare a failing and a passing test](https://replay.help/playwright-flake-debug) to detect the difference. This can be caused by inconsistent data, race condition, the test running too fast, or any other reason. What’s important is that the reason will no longer be a mystery, because Replay Browser records your test steps, your app, and everything in between. If you were able to capture the test flake, you’ll be able to debug it. Soon, we’ll be able to [help you find the root cause](/basics/test-suites/root-cause-analysis).
 

--- a/src/app/reference/integrations/replay-apis/graphql-api/page.md
+++ b/src/app/reference/integrations/replay-apis/graphql-api/page.md
@@ -1,33 +1,34 @@
 ---
 title: GraphQL API
 ---
-The GraphQL API is useful for fetching workspace and user metadata including recordings, users that belong to a team, and comments added to a recording.
+
+The GraphQL API is useful for fetching workspace and user metadata including replays, users that belong to a team, and comments added to a replay.
 
 ```javascript
 try {
-    const resp = await fetch("https://api.replay.io/v1/graphql", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify({
-        variables: {},
-        query: query,
-      }),
-    });
- 
-    const json = await resp.json();
- 
-    if (json.errors) {
-      throw new Error(json.errors[0].message);
-    } else if (!json.data) {
-      throw new Error("No data was returned");
-    }
- 
-    return json;
-  } catch (e) {
-    console.log(e && e.message);
-    return null;
+  const resp = await fetch('https://api.replay.io/v1/graphql', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      variables: {},
+      query: query,
+    }),
+  })
+
+  const json = await resp.json()
+
+  if (json.errors) {
+    throw new Error(json.errors[0].message)
+  } else if (!json.data) {
+    throw new Error('No data was returned')
   }
+
+  return json
+} catch (e) {
+  console.log(e && e.message)
+  return null
+}
 ```

--- a/src/app/reference/integrations/replay-apis/replay-driver/page.md
+++ b/src/app/reference/integrations/replay-apis/replay-driver/page.md
@@ -1,6 +1,6 @@
 ---
 title: Replay Driver
-description: The Replay Driver is a dynamically linked library which can be loaded by applications which want to record their behavior and upload those recordings for inspection using the Replay Protocol.
+description: The Replay Driver is a dynamically linked library which can be loaded by applications which want to record their behavior and upload those replay for inspection using the Replay Protocol.
 image: /images/chrome.png
 ---
 

--- a/src/app/reference/replay-cli/source-maps/page.md
+++ b/src/app/reference/replay-cli/source-maps/page.md
@@ -8,7 +8,7 @@ Source maps exist to try and preserve the original debugging experience as best 
 
 ## Upload Process
 
-For production use cases where sourcemaps may not be exposed publicly, we provide tooling for preemptively uploading sourcemaps to our servers so that when recordings are made, they can make use of these maps. We provide both a CLI command, and a Webpack plugin to make integrating this into your build process as easy as possible.
+For production use cases where sourcemaps may not be exposed publicly, we provide tooling for preemptively uploading sourcemaps to our servers so that when replays are made, they can make use of these maps. We provide both a CLI command, and a Webpack plugin to make integrating this into your build process as easy as possible.
 
 ### API Keys
 

--- a/src/app/reference/security-and-privacy/privacy-principles/page.md
+++ b/src/app/reference/security-and-privacy/privacy-principles/page.md
@@ -10,4 +10,4 @@ We know that in order for Replay to become your daily debugging tool we need to 
 
 3.  **Browser privacy model.** When you’re debugging a replay, we run the browser in a secure sandbox that only trusted users can access. For more information, see our [security practices](/reference/security-and-privacy/security-practices).
 
-4.  **You own your data.** Recordings are encrypted at rest and only available to trusted users. You can delete your own data at any point.
+4.  **You own your data.** Replays are encrypted at rest and only available to trusted users. You can delete your own data at any point.

--- a/src/app/reference/security-and-privacy/security-practices/page.md
+++ b/src/app/reference/security-and-privacy/security-practices/page.md
@@ -36,7 +36,7 @@ Replay runs on top of Firefox, Chromium, and Node. It benefits from the security
 
 ### Design and Architecture
 
-Maintaining the security of our infrastructure is simple because viewing a Replay does not make real network connections, interactions with the filesystem, or other syscalls. When viewing a Replay, your recording is containerized in a separate kubernetes pod from other recordings.
+Maintaining the security of our infrastructure is simple because viewing a Replay does not make real network connections, interactions with the filesystem, or other syscalls. When viewing a Replay, your recording is containerized in a separate kubernetes pod from other replays.
 
 ### We anonymize production data before using it for testing.
 
@@ -48,7 +48,7 @@ We use Tailscale as a VPN to provide secure access to our network.
 
 ### We provide the security features you need
 
-Your Replay recordings are yours, not ours. We offer “_Bring your own bucket_” to our enterprise customers. All customers are able to use SSO and OIDC without any additional cost, without an [**SSO tax**](https://sso.tax/).
+Your replays are yours, not ours. We offer “_Bring your own bucket_” to our enterprise customers. All customers are able to use SSO and OIDC without any additional cost, without an [**SSO tax**](https://sso.tax/).
 
 ## Privacy + Security Policies
 

--- a/src/app/reference/test-runners/cypress-io/recording-options/page.md
+++ b/src/app/reference/test-runners/cypress-io/recording-options/page.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-description: There are different modes and strategies that help you create your recordings more effectively. By default, every test is recorded, but you can choose to create your recordings only when problems appear, saving costs and time.
+description: There are different modes and strategies that help you create your replays more effectively. By default, every test is recorded, but you can choose to create your replays only when problems appear, saving costs and time.
 ---
 
 ## Diagnostic Modes

--- a/src/app/reference/test-runners/playwright/github-actions/page.md
+++ b/src/app/reference/test-runners/playwright/github-actions/page.md
@@ -62,7 +62,7 @@ In most setups, you'll want to to have additional control. In these cases, it's 
 
 ### Only uploading failed tests
 
-By default, all test replays are uploaded no matter the result. If you want to only upload the failed recordings, you can do so by passing the `filter` property to the `replayio/action-upload` action:
+By default, all test replays are uploaded no matter the result. If you want to only upload the failed replays, you can do so by passing the `filter` property to the `replayio/action-upload` action:
 
 ```yml {% fileName=".github/workflows/e2e.yml" lineNumbers=true highlight=["13-18"] %}
 name: Replay tests

--- a/src/app/reference/test-runners/selenium/page.md
+++ b/src/app/reference/test-runners/selenium/page.md
@@ -4,29 +4,39 @@ description: Because Replay Browser lets you record anything that happens inside
 ---
 
 {% steps %}
+
 ## Install Replay package
+
 To start, you need to install `@replayio/replay` package to your project.
 
 {% tabs labels=["npm", "yarn", "pnpm", "bun"] %}
 {% tab %}
+
 ```sh
 npm i replayio
 ```
+
 {% /tab %}
 {% tab %}
+
 ```sh
 yarn add replayio
 ```
+
 {% /tab %}
 {% tab %}
+
 ```sh
 pnpm i replayio
 ```
+
 {% /tab %}
 {% tab %}
+
 ```sh
 bun i replayio
 ```
+
 {% /tab %}
 {% /tabs %}
 
@@ -35,32 +45,37 @@ bun i replayio
 In order to use Replay Browser in your Selenium scripts, you need to point your configuration to the Replay Browser binary. The `getBrowserPath` function will take care of locating the binary on your machine.
 
 ```js {% lineNumbers=true fileName="spec.js" highlight=[3,5,"7-8",12] %}
-const { Builder, Browser, By, until } = require('selenium-webdriver');
-const chrome = require('selenium-webdriver/chrome');
-import { getBrowserPath } from "replayio";
+const { Builder, Browser, By, until } = require('selenium-webdriver')
+const chrome = require('selenium-webdriver/chrome')
+import { getBrowserPath } from 'replayio'
 
-const chromiumPath = getBrowserPath();
+const chromiumPath = getBrowserPath()
 
-(async function test() {
-  let options = new chrome.Options();
-  options.setChromeBinaryPath(chromiumPath);
+;(async function test() {
+  let options = new chrome.Options()
+  options.setChromeBinaryPath(chromiumPath)
 
   let driver = await new Builder()
     .forBrowser(Browser.CHROME)
     .setChromeOptions(options)
-    .build();
+    .build()
 
-    try {
-      await driver.get('http://localhost:3000');
-      await driver.findElement(By.xpath("//*[text()='Add to Cart']")).click();
-      await driver.wait(until.elementLocated(By.xpath("//*[text()='Product added to cart!']")), 5000);
-    } finally {
-      await driver.quit();
-    }
-})();
+  try {
+    await driver.get('http://localhost:3000')
+    await driver.findElement(By.xpath("//*[text()='Add to Cart']")).click()
+    await driver.wait(
+      until.elementLocated(By.xpath("//*[text()='Product added to cart!']")),
+      5000,
+    )
+  } finally {
+    await driver.quit()
+  }
+})()
 ```
+
 ## Run your tests
-With configration set up, you can run your tests the same way as before. After your run finishes, your recordings will be stored locally. 
+
+With configration set up, you can run your tests the same way as before. After your run finishes, your recordings will be stored locally.
 
 ## Upload your replays
 
@@ -69,6 +84,7 @@ Upload your replays with the following command:
 ```sh
 replayio upload --all
 ```
+
 To learn more see the [docs on Replay CLI](/reference/replay-cli/commands).
 
 After you upload your recordings, you can view them in [Test Suite Dashboard](/basics/test-suites/recent-runs).
@@ -106,7 +122,6 @@ After you upload your recordings, you can view them in [Test Suite Dashboard](/b
 
 {% /quick-links %}
 
-
 <!-- ## Continuous integration
 To run your project on CI, you’ll simply follow the same steps as described above. In addition to running your tests and uploading your replays, you need to make sure that your CI environment is set up properly.
 
@@ -122,9 +137,9 @@ orbs:
   browser-tools: circleci/browser-tools@1.4.6
 jobs:
   replay:
-    environment: 
+    environment:
       RECORD_ALL_CONTENT: 1
-    executor: node/default 
+    executor: node/default
     steps:
       - checkout
       - node/install-packages:
@@ -132,19 +147,19 @@ jobs:
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
       - run:
-          name: Run e2e tests 
+          name: Run e2e tests
           command: npm test
       - run:
           name: Upload replays
           when: always
           command: npx @replayio/replay upload-all
-      
+
 workflows:
   replay-workflow:
     jobs:
       - replay
 ```
 
-After tests are ran, the `Upload replays` step is executed. notice the `when: always` option that ensures we run this steps independently from whether previous step fails or passes. This ensures we will upload recordings of failed tests and don’t stop the pipeline execution on previous step.
+After tests are run, the `Upload replays` step is executed. notice the `when: always` option that ensures we run this steps independently from whether previous step fails or passes. This ensures we will upload replays of failed tests and don’t stop the pipeline execution on previous step.
 
 The `Upload replays` step relies on `REPLAY_API_KEY` being present in the environment. To generate an API key, follow [these docs](/basics/replay-teams/setting-up-a-team#api-keys). To set up your API key in your CircleCI project, follow the [documentation on CircleCI](https://circleci.com/docs/set-environment-variable/#set-an-environment-variable-in-a-project) -->


### PR DESCRIPTION
**Background**

We've talked for a long time about how we should use the word "replay" instead of "recording." [Here's a Linear task](https://linear.app/replay/issue/DES-1398/find-and-remove-the-word-recording-in-favor-of-the-word-replay) for tracking that.

**Easy changes, hard changes, pitfalls**

Easy: "Once your recording is uploaded, you can inspect it with Replay DevTools." This is easy to change to make. Recording should be changed to replay.

Pitfalls: "Runtime Replay refers to the act of recording the underlying runtime so you can replay it later exactly as it ran before." This is a place where a simple find/replace wouldn't work, because the verb "recording" is appropriate, and the verb "replaying" wouldn't be.

Hard: This part gets harder because our CLI refers to "recording" URLs, which is appropriate. And we use the verb "record" which is also appropriate. The tricky bit is when we say "Successfully uploaded 2 recordings." We just used the verb "record" so this could go either way. We could say "Successfully uploaded 2 replays" or keep it as is. We should discuss.
<img width="705" alt="image" src="https://github.com/replayio/docs/assets/9154902/05258e89-d07f-4d51-a27f-425e0a614549">

**Proposal**

If we do decide to update the CLI docs to say "Successfully uploaded 2 replays," we'll also want to update the CLI itself. That's fine, but it's a bigger lift.

On the other hand, we could decide that the CLI sticks with the phrasing "record" but we can update everywhere else in the docs to say "replay." Both are fine, and I don't think the difference is too significant. We should discuss.