### PR TITLE
Revamp "Upload Sourcemaps" page with options, deletion instructions, and better Next example

### DIFF
--- a/src/app/reference/replay-cli/source-maps/page.md
+++ b/src/app/reference/replay-cli/source-maps/page.md
@@ -23,6 +23,7 @@ You can upload source maps using the `replayio upload-source-maps` command in th
 The simplest usage will be running the following after your production JS build has finished.
 
 ```sh
+npm run build
 npx replayio upload-source-maps --group <Version or SHA> <buildOutputDir>
 ```
 

--- a/src/app/reference/replay-cli/source-maps/page.md
+++ b/src/app/reference/replay-cli/source-maps/page.md
@@ -234,7 +234,9 @@ const nextConfig = {
 module.exports = nextConfig
 ```
 
-As mentioned, NextJS's `buildId` can be useful, but please [see their docs](https://nextjs.org/docs/api-reference/next.config.js/configuring-the-build-id) to ensure verify if it is a good fit for your application.
+You can see [a full working example of Next config with sourcemap deletion here](https://github.com/replayio-public/replay-sourcemap-upload-example/blob/main/next.config.mjs), and check out [the demo site](https://replay-sourcemap-upload-example-site.vercel.app/) to confirm that the original app source code is not included in the production site.
+
+Also see the Next.js [docs on "Configuring the Build ID"](https://nextjs.org/docs/api-reference/next.config.js/configuring-the-build-id) for details on generating a consistent build ID, such as with a Git hash.
 
 ## Debugging problems
 

--- a/src/app/reference/replay-cli/source-maps/page.md
+++ b/src/app/reference/replay-cli/source-maps/page.md
@@ -8,89 +8,235 @@ Source maps exist to try and preserve the original debugging experience as best 
 
 ## Upload Process
 
-For production use cases where sourcemaps may not be exposed publicly, we provide tooling for preemptively uploading sourcemaps to our servers so that when replays are made, they can make use of these maps. We provide both a CLI command, and a Webpack plugin to make integrating this into your build process as easy as possible.
+For production use cases where sourcemaps may not be exposed publicly, we provide tooling for preemptively uploading sourcemaps to our servers so that when replays are made, they can make use of these maps and you can still debug the recordings with the original source code. We provide both a CLI command and a Webpack plugin to make integrating this into your build process as easy as possible.
 
 ### API Keys
 
 We recommend using the `REPLAY_API_KEY` environment variable to set up the API for use in all of our following examples, but each also allows passing the key directly as an argument. API Keys are available in the [Team Settings](/reference/ci-workflows/generate-api-key) modal.
 
-### CLI
+**Be sure to add the `REPLAY_API_KEY` for the workspace to the build and deployment settings for your project**, such as in Vercel or Github Actions - it needs to be available during the build step in order for the upload logic to upload successfully.
 
-You can upload source maps using the `upload-sourcemaps` command in the Replay CLI.
+## CLI
+
+You can upload source maps using the `replayio upload-source-maps` command in the [Replay CLI](/reference/replay-cli/commands).
 
 The simplest usage will be running the following after your production JS build has finished.
 
 ```sh
-npx replayio upload-sourcemaps --group <Version or SHA> <buildOutputDir>
+npx replayio upload-source-maps --group <Version or SHA> <buildOutputDir>
 ```
 
 You must ensure that your build tool is configured to output sourcemaps into the build directory you provide.
 
-### Webpack
+### CLI Options
 
-The `sourcemap-upload` Webpack plugin is available on npm at `@replayio/sourcemap-upload-webpack-plugin` and you can explore the available options at [sourcemap-upload-webpack-plugin](https://github.com/replayio/replay-cli/tree/main/packages/sourcemap-upload-webpack-plugin) and [sourcemap-upload](https://github.com/replayio/replay-cli/tree/main/packages/sourcemap-upload).
+The `replayio upload-source-maps` command has options available to help locate and filter which sourcemaps are available. Currently, those options are:
 
-The simplest usage will be to edit your `webpack.config.js` to include a new entry in the `plugins` array at the top level of the file, e.g.
+```bash
+-g, --group <name>       The name to group this source map into, e.g. A commit SHA or release version.
+-x, --extensions <exts>  A comma-separated list of file extensions to process; default ".js,.map"
+-i, --ignore <pattern>   Ignore files that match this pattern
+--root <dirname>         The base directory to use when computing relative paths
+```
 
-```javascript
-const ReplaySourceMapUploadWebpackPlugin = require("@replayio/sourcemap-upload-webpack-plugin");
+## Webpack
+
+We have a Webpack plugin that can upload sourcemaps, available on NPM as [`@replayio/sourcemap-upload-webpack-plugin`](https://npmjs.com/package/@replayio/sourcemap-upload-webpack-plugin).
+
+To use the plugin, edit your `webpack.config.js` to include a new entry in the `plugins` array at the top level of the file, e.g.
+
+```js
+const ReplaySourceMapUploadWebpackPlugin = require('@replayio/sourcemap-upload-webpack-plugin')
 
 module.exports = {
   // Ensure that Webpack has been configured to output sourcemaps.
-  devtool: "source-map",
-  // ...  plugins:
-  [
-  // Enable our plugin to upload the sourcemaps once the build has completed.
-  // This assumes NODE_ENV is how you distinguish production builds. If that
-  // is not the case for you, you will have to tweak this logic.
-  process.env.NODE_ENV === "production"
-    ? [new ReplaySourceMapUploadWebpackPlugin({
-       filepaths: ["outputDir/"],
-       group: "<A unique version string or git SHA>"
-  })]
-  : []
+  devtool: 'source-map',
+  // ...
+  plugins: [
+    // Enable our plugin to upload the sourcemaps once the build has completed.
+    // This assumes NODE_ENV is how you distinguish production builds. If that
+    // is not the case for you, you will have to tweak this logic.
+    process.env.NODE_ENV === 'production'
+      ? [
+          new ReplaySourceMapUploadWebpackPlugin({
+            filepaths: ['outputDir/'],
+            group: '<A unique version string or git SHA>',
+          }),
+        ]
+      : [],
   ],
 }
 ```
 
-Keep in mind that your build output will now contain sourcemaps, so you should take care to ensure that these maps aren't also exposed on your production site.
+### Webpack Upload Plugin Options
+
+The Webpack plugin accepts several options to configure searching for sourcemaps and build artifacts on disk, excluding them from upload, and configuring deletion.
+
+```ts
+// Exported from `@replayio/sourcemap-upload`
+export interface UploadOptions {
+  /**
+   * The files/directories to search for sourcemaps. All files that match the
+   * 'extensions' list and fail to match 'ignore' will be searched for
+   * sourcemap JSON or `//#sourceMappingURL=` coments in order to find pairs
+   * of generated-file + sourcemap, and the sourcemap will be uploaded.
+   */
+  filepaths: Array<string> | string
+  /**
+   * To allow for tracking and browsing of maps that have been uploaded, we
+   * require uploaded sourcemaps to have an overall group name associated with
+   * them. This could for instance be a version number, or commit hash.
+   */
+  group: string
+  /**
+   * The API key to use when connecting to Replay's servers.
+   * Defaults to `process.env.REPLAY_API_KEY`.
+   */
+  key?: string
+  /**
+   * Run all of the local processing and searching for maps, but skip uploading them.
+   */
+  dryRun?: boolean
+  /**
+   * Delete all found sourcemap files after they have been uploaded.
+   */
+  deleteAfterUpload?: boolean
+  /**
+   * If sourcemaps can't be matched to generated files by their sourceMappingURL, try matching by filenames on disk
+   */
+  matchSourcemapsByFilename?: boolean
+  /**
+   * The set of file extensions to search for sourcemap-related data.
+   * Defaults to [".js", ".map"].
+   */
+  extensions?: Array<string>
+  /**
+   * The set of pattern for files to ignore when searching for sourcemap-related data.
+   */
+  ignore?: Array<string>
+  /**
+   * Set the directory that relative paths should be computed with respect to.
+   * The relative path of sourcemaps is included in the uploaded entry, and will be
+   * visible in the UI, so this can be used to strip off unimportant directories in
+   * the build path. Defaults to `process.cwd()`.
+   */
+  root?: string
+  /**
+   * A callback function that will be called with log messages.
+   */
+  log?: LogCallback
+  /**
+   * URL of the Replay server to upload to. Defaults to `https://api.replay.io`.
+   */
+  server?: string
+  /**
+   * The number of concurrent uploads to perform. Defaults to 25.
+   */
+  concurrency?: number
+  /**
+   * A string to append to the User-Agent header when making requests to the Replay API.
+   */
+  userAgentAddition?: string
+}
+
+// Exported from `@replayio/sourcemap-upload-webpack-plugin`
+export interface PluginOptions extends UploadOptions {
+  // Choose how verbose the plugin should be when logging.
+  logLevel?: 'quiet' | 'normal' | 'verbose'
+
+  // Normally failure to upload the sourcemaps will result
+  // in a build error. If you'd like to simply warn instead
+  // of failing in this case, you can set this to true.
+  warnOnFailure?: boolean
+}
+```
+
+### Sourcemap Visibility in Production
+
+Keep in mind that your build output will now contain sourcemaps, and so your app source code will be viewable in the browser devtools for anyone viewing your production site.
+
+If this is a concern for you, you can keep your sourcemaps hidden from end users by deleting them from the build output directory. The Replay Webpack plugin has a `deleteAfterUpload` option to allow this. You can also configure Webpack's sourcemap generation settings to use [`devtool: "hidden-source-map"`](https://webpack.js.org/configuration/devtool/#production), which skips adding a `sourceMappingURL` reference to the generated JS build artifacts to keep the browser from trying to download and view sourcemaps. If you enable that, you should also enable the Webpack plugin's `matchSourcemapsByFilename` option, to ensure the plugin still correctly finds the right sourcemaps:
+
+```js
+const ReplaySourceMapUploadWebpackPlugin = require('@replayio/sourcemap-upload-webpack-plugin')
+
+module.exports = {
+  // Ensure that Webpack has been configured to output sourcemaps,
+  // but without the `sourceMappingURL` references in buidl artifacts.
+  devtool: 'hidden-source-map',
+  // ...
+  plugins: [
+    // Enable our plugin to upload the sourcemaps once the build has completed.
+    // This assumes NODE_ENV is how you distinguish production builds. If that
+    // is not the case for you, you will have to tweak this logic.
+    process.env.NODE_ENV === 'production'
+      ? [
+          new ReplaySourceMapUploadWebpackPlugin({
+            filepaths: ['outputDir/'],
+            group: '<A unique version string or git SHA>',
+            deleteAfterUpload: true,
+            matchSourcemapsByFilename: true,
+          }),
+        ]
+      : [],
+  ],
+}
+```
+
+The Replay Webpack plugin uploads sourcemaps to the workspace associated with your API key, and automatically matches up sourcemaps with the build artifacts in a recorded replay when you debug it. This way, you can avoid having sourcemaps visible on your production site, but still debug replays with the original source code.
 
 ### NextJS
 
 NextJS uses Webpack internally, so the plugin above will also be used for NextJS, but the config that needs editing is `next.config.js` instead. NextJS's [own documentation](https://nextjs.org/docs/api-reference/next.config.js/custom-webpack-config) is a good place to start and shows how to add Webpack plugins to your build process. You'll also need to enable [production sourcemaps](https://nextjs.org/docs/advanced-features/source-maps), so you'll end up with the following additional config in your `next.config.js` file:
 
-```javascript
-module.exports = {
+```ts
+/** @type {import('next').NextConfig} */
+const nextConfig = {
   productionBrowserSourceMaps: true,
-  webpack: (config, { buildId, dev, isServer }) => {
-    if (!dev && !isServer) {
-      config.plugins.push(
-        new ReplaySourceMapUploadWebpackPlugin({
-          // If you've configured a custom build directory, this should
-          // point to that directory.          filepaths: [".next/"],
-          // Potentially the 'buildId' argument here could be used.
-          group: '<A unique version string or git SHA>',
-        }),
-      )
-      // 'productionBrowserSourceMaps' will output your sourcemaps
-      // into the build directory, which can expose them from your
-      // production server as well, so you will likely want to delete
-      // the .map files once they have been uploaded.
 
-      config.plugins.push((compiler) =>
-        compiler.hooks.afterEmit.tapPromise('DeleteSourceMaps', () =>
-          findAndDeleteSourceMaps(),
-        ),
-      )
+  webpack: (config, { isServer, dev, buildId }) => {
+    /** @type {import('webpack').Configuration} */
+    const webpackConfig = config
+
+    // This configures Webpack to generate sourcemaps, but not include
+    // the `sourceMappingURL` reference in generated JS bundles.
+    // This keeps the sourcemaps hidden from users, but still available
+    webpackConfig.devtool = 'hidden-source-map'
+
+    if (!dev && !isServer) {
+      /** @type {import('@replayio/sourcemap-upload-webpack-plugin').PluginOptions} */
+      const uploadOptions = {
+        // If you've configured a custom build directory, this should point to that directory.
+        filepaths: ['.next/'],
+        // You can use `buildId` here to differentiate sourcemaps between different builds.
+        group: buildId,
+
+        // Don't upload or delete server-related sourcemaps
+        ignore: ['**/server/**'],
+        // You can configure the plugin to automatically delete sourcemaps from the local build
+        // output folder after they've been uploaded, to keep them from being visible to users.
+        deleteAfterUpload: true,
+        // When `devtool: "hidden-source-map"` is used, the upload plugin can't match up
+        // sourcemaps with bundles automatically because there's no `sourceMappingURL`.
+        // Set this to true to match them up by similar filenames instead.
+        matchSourcemapsByFilename: true,
+        // The plugin will look for the API key as `process.env.REPLAY_API_KEY` by default.
+        // You can provide it here if it's stored in a different environment variable.
+        // key: process.env.REPLAY_API_KEY,
+      }
+      config.plugins.push(new ReplaySourceMapUploadWebpackPlugin(uploadOptions))
     }
+
     return config
   },
 }
+
+module.exports = nextConfig
 ```
 
 As mentioned, NextJS's `buildId` can be useful, but please [see their docs](https://nextjs.org/docs/api-reference/next.config.js/configuring-the-build-id) to ensure verify if it is a good fit for your application.
 
-### Debugging problems
+## Debugging problems
 
 Each of these approaches will log the sourcemaps as they are uploaded so that you can validate that all of the files you expect are being detected. They each also have a verbose mode, either `logLevel: "verbose"` for the JS plugins, and `--verbose` for the CLI.
 

--- a/src/app/reference/test-runners/playwright/github-actions/page.md
+++ b/src/app/reference/test-runners/playwright/github-actions/page.md
@@ -4,7 +4,7 @@ title: GitHub actions
 
 Playwright tests can be configured via `playwright.config.ts` and the [command line](https://playwright.dev/docs/test-cli).
 
-In real world scenarios, the `playwright.config.ts` has the defualt setup and is extended by the command line options in either the terminal, `package.json` or github action.
+In real world scenarios, the `playwright.config.ts` has the default setup and is extended by the command line options in either the terminal, `package.json` or github action.
 
 ## Simple setup
 
@@ -46,15 +46,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      # If you're using Yarn or PNPM, use the appropriate install command here
       - name: Install dependencies
         run: npm ci
       - name: Install Replay Chromium
         run: npx replayio install
       - name: Run Playwright tests
-        run: npx playwright test
+        run: npx playwright test --project replay-chromium
         env:
           REPLAY_API_KEY: ${{ secrets.REPLAY_API_KEY }}
 ```
+
+Finally, add the workspace API key you were given to the Github repo settings as `REPLAY_API_KEY`, so that the CI job uploads to the right workspace.
 
 ## Advanced setup
 


### PR DESCRIPTION
This PR:

- Fixes a couple of typos and instruction tweaks I found while following the Playwright setup steps
- Revamps the "Upload Sourcemaps" page:
  - Emphasizes adding the API key to repo secrets for the build process
  - Lists the current CLI options
  - Lists the current Webpack plugin options with doc comments
  - Adds a section on "Sourcemap Visibility in Production", with deletion instructions
  - Updates the "NextJS" section with the full example config and a link to the example project