### PR TITLE
Remove recording options section from the Playwright's overview page

### DIFF
--- a/src/app/reference/test-runners/playwright/overview/page.md
+++ b/src/app/reference/test-runners/playwright/overview/page.md
@@ -20,13 +20,6 @@ npx playwright test --project replay-chromium
 /%}
 
 {% quick-link
-  title="Recording options"
-  icon="record"
-  href="/reference/test-runners/playwright/playwright-core"
-  description="Use the Replay browser to record Playwright core tests"
-/%}
-
-{% quick-link
   title="GitHub Actions"
   icon="github"
   href="/reference/test-runners/playwright/github-actions"


### PR DESCRIPTION
This one doesn't exist so the link feels broken as it brings us to a generic~ page.