### PR TITLE
Add Replay QA docs section

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -520,72 +520,84 @@ packages:
     engines: {glibc: '>=2.26', npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.0':
     resolution: {integrity: sha512-VwgD2eEikDJUk09Mn9Dzi1OW2OJFRQK+XlBTkUNmAWPrtj8Ly0yq05DFgu1VCMx2/DqCGQVi5A1dM9hTmxf3uw==}
     engines: {glibc: '>=2.28', npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.0':
     resolution: {integrity: sha512-o9E46WWBC6JsBlwU4QyU9578G77HBDT1NInd+aERfxeOPbk0qBZHgoDsQmA2v9TbqJRWzoBPx1aLOhprBMgPjw==}
     engines: {glibc: '>=2.28', npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.0':
     resolution: {integrity: sha512-naldaJy4hSVhWBgEjfdBY85CAa4UO+W1nx6a1sWStHZ7EUfNiuBTTN2KUYT5dH1+p/xij1t2QSXfCiFJoC5S/Q==}
     engines: {glibc: '>=2.26', npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.0':
     resolution: {integrity: sha512-OdorplCyvmSAPsoJLldtLh3nLxRrkAAAOHsGWGDYfN0kh730gifK+UZb3dWORRa6EusNqCTjfXV4GxvgJ/nPDQ==}
     engines: {musl: '>=1.2.2', npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.0':
     resolution: {integrity: sha512-FW8iK6rJrg+X2jKD0Ajhjv6y74lToIBEvkZhl42nZt563FfxkCYacrXZtd+q/sRQDypQLzY5WdLkVTbJoPyqNg==}
     engines: {musl: '>=1.2.2', npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.1':
     resolution: {integrity: sha512-59B5GRO2d5N3tIfeGHAbJps7cLpuWEQv/8ySd9109ohQ3kzyCACENkFVAnGPX00HwPTQcaBNF7HQYEfZyZUFfw==}
     engines: {glibc: '>=2.26', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.1':
     resolution: {integrity: sha512-Ii4X1vnzzI4j0+cucsrYA5ctrzU9ciXERfJR633S2r39CiD8npqH2GMj63uFZRCFt3E687IenAdbwIpQOJ5BNA==}
     engines: {glibc: '>=2.28', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.1':
     resolution: {integrity: sha512-tRGrb2pHnFUXpOAj84orYNxHADBDIr0J7rrjwQrTNMQMWA4zy3StKmMvwsI7u3dEZcgwuMMooIIGWEWOjnmG8A==}
     engines: {glibc: '>=2.28', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.1':
     resolution: {integrity: sha512-4y8osC0cAc1TRpy02yn5omBeloZZwS62fPZ0WUAYQiLhSFSpWJfY/gMrzKzLcHB9ulUV6ExFiu2elMaixKDbeg==}
     engines: {glibc: '>=2.26', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.1':
     resolution: {integrity: sha512-D3lV6clkqIKUizNS8K6pkuCKNGmWoKlBGh5p0sLO2jQERzbakhu4bVX1Gz+RS4vTZBprKlWaf+/Rdp3ni2jLfA==}
     engines: {musl: '>=1.2.2', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.1':
     resolution: {integrity: sha512-LOGKNu5w8uu1evVqUAUKTix2sQu1XDRIYbsi5Q0c/SrXhvJ4QyOx+GaajxmOg5PZSsSnCYPSmhjHHsRBx06/wQ==}
     engines: {musl: '>=1.2.2', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.33.1':
     resolution: {integrity: sha512-vWI/sA+0p+92DLkpAMb5T6I8dg4z2vzCUnp8yvxHlwBpzN8CIcO3xlSXrLltSvK6iMsVMNswAv+ub77rsf25lA==}
@@ -785,42 +797,49 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/snappy-linux-arm64-musl@7.3.3':
     resolution: {integrity: sha512-AAED4cQS74xPvktsyVmz5sy8vSxG/+3d7Rq2FDBZzj3Fv6v5vux6uZnECPCAqpALCdTtJ61unqpOyqO7hZCt1Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/snappy-linux-ppc64-gnu@7.3.3':
     resolution: {integrity: sha512-pofO5eSLg8ZTBwVae4WHHwJxJGZI8NEb4r5Mppvq12J/1/Hq1HecClXmfY3A7bdT2fsS2Td+Q7CI9VdBOj2sbA==}
     engines: {node: '>= 10'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/snappy-linux-riscv64-gnu@7.3.3':
     resolution: {integrity: sha512-OiHYdeuwj0TVBXADUmmQDQ4lL1TB+8EwmXnFgOutoDVXHaUl0CJFyXLa6tYUXe+gRY8hs1v7eb0vyE97LKY06Q==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/snappy-linux-s390x-gnu@7.3.3':
     resolution: {integrity: sha512-66QdmuV9CTq/S/xifZXlMy3PsZTviAgkqqpZ+7vPCmLtuP+nqhaeupShOFf/sIDsS0gZePazPosPTeTBbhkLHg==}
     engines: {node: '>= 10'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/snappy-linux-x64-gnu@7.3.3':
     resolution: {integrity: sha512-g6KURjOxrgb8yXDEZMuIcHkUr/7TKlDwSiydEQtMtP3n4iI4sNjkcE/WNKlR3+t9bZh1pFGAq7NFRBtouQGHpQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/snappy-linux-x64-musl@7.3.3':
     resolution: {integrity: sha512-6UvOyczHknpaKjrlKKSlX3rwpOrfJwiMG6qA0NRKJFgbcCAEUxmN9A8JvW4inP46DKdQ0bekdOxwRtAhFiTDfg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/snappy-openharmony-arm64@7.3.3':
     resolution: {integrity: sha512-I5mak/5rTprobf7wMCk0vFhClmWOL/QiIJM4XontysnadmP/R9hAcmuFmoMV2GaxC9MblqLA7Z++gy8ou5hJVw==}
@@ -894,24 +913,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@14.2.33':
     resolution: {integrity: sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@14.2.33':
     resolution: {integrity: sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@14.2.33':
     resolution: {integrity: sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@14.2.33':
     resolution: {integrity: sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==}
@@ -1587,41 +1610,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}

--- a/src/app/basics/replay-qa/overview/page.mdx
+++ b/src/app/basics/replay-qa/overview/page.mdx
@@ -1,0 +1,114 @@
+---
+title: Replay QA Overview
+description: An autonomous app testing tool that explores your web app, writes tests, captures Replay recordings, and delivers root cause analysis and suggested fixes for every bug it finds.
+---
+
+Replay QA is an autonomous app testing tool built on Replay's time-travel debugging engine. Point it at a web app and it explores the application, discovers user journeys, writes Playwright tests, executes them while capturing full runtime recordings, and uncovers bugs — delivering a detailed root cause analysis and suggested fix for every issue it finds.
+
+There are three ways to use Replay QA depending on your workflow.
+
+**A few tips for best results:**
+
+1. **React-based apps work best.** Replay QA has deep React support — component tree inspection, render tracing, and effect analysis — that significantly improves the depth of bug reports for React apps.
+2. **Publish your app with source maps.** When source maps are available, Replay QA traces failures back to your original source code rather than compiled output, producing root cause analyses and suggested fixes that reference the right files and line numbers. [Learn more](/basics/replay-qa/source-maps)
+
+## Stand-alone
+
+Give Replay QA a URL. It takes it from there.
+
+Replay QA autonomously navigates your application, discovers user journeys, and generates Playwright tests. It then executes those tests using Replay Browser — capturing a full runtime recording of every interaction. When it uncovers a bug or unexpected behavior, it time-travels the recording to trace the failure back to its root cause, and delivers a detailed analysis with a suggested fix.
+
+This requires no existing test suite, no configuration, and no manual reproduction steps.
+
+<Button href="https://qa.replay.io">Launch Replay QA</Button>
+
+## Ask your coding agent
+
+Give your coding agent the prompt below and it will use the Replay QA REST API to create a new project for your app, poll for status as Replay QA explores and tests the application, and ingest the resulting bug reports — each packaged with the runtime context and root cause detail your agent needs to go straight to a fix. It keeps looping until no open bugs remain.
+
+```text
+Set up a continuous QA loop for the app we're building using Replay QA (https://loop-qa.replay.io).
+
+Drive everything through the REST API at https://loop-qa.replay.io/api/v1 — read the OpenAPI spec at /api/v1/openapi.json first; it documents the full workflow. Authenticate with my API token ("Authorization: Bearer lqa_..."), asking me for it if needed.
+
+Your job:
+1. Create a QA project for the running app — give it the target_url and a short note on the key flows. If the app is only reachable from this machine (e.g. http://localhost:3000), enable the reverse proxy and follow the spec's setup steps.
+2. Let QA run — poll the project status and don't kick off explorations or test runs yourself; QA drives those.
+3. For each open bug, read its full root-caused report and apply the fix directly in the codebase, then mark it fixed via the API.
+4. Keep looping until no open bugs remain.
+```
+
+## Integrated into your CI pipeline
+
+Install our GitHub bot (CI Agent) and configure your test suite to record with Replay. From that point, every test run in CI produces a Replay runtime recording. When a test fails, the CI Agent time-travels the recording, and posts a comment directly on the pull request with:
+
+- A plain-language root cause explanation
+- A trace showing the execution chain from symptom to cause
+- A suggested code fix with file and line references
+
+No reproduction steps. No log archaeology. The evidence is already in the recording.
+
+See [GitHub Actions setup](/basics/getting-started/record-your-playwright-tests/github-actions) to configure Replay in your workflow, and [PR Comments](/basics/test-suites/pr-comments) to install the GitHub bot.
+
+## How Replay's time-travel engine works
+
+All three modes share the same foundation: **deterministic browser recordings** captured by Replay Browser. Unlike video or snapshots, a Replay recording captures the full browser runtime — every DOM change, every network request, every line of JavaScript execution.
+
+That means any point in a test run can be inspected retroactively: add console logs, evaluate expressions, examine call stacks, trace render behavior — all without re-running the test.
+
+[Learn more about how time-travel debugging works →](/basics/time-travel/why-time-travel)
+
+## FAQ
+
+<Accordion>
+
+<AccordionItem title="Do I need an existing test suite to use Replay QA?">
+
+No. In stand-alone mode, Replay QA writes and runs its own Playwright tests from scratch. If you already have a test suite, the CI pipeline integration mode builds on top of it.
+
+</AccordionItem>
+
+<AccordionItem title="What does a bug report from Replay QA contain?">
+
+Each bug report includes a plain-language description of the issue, a root cause analysis traced through the runtime recording, and a suggested fix with specific file and line references. In stand-alone and agentic modes, reports are structured to give a coding agent everything it needs to act on the finding directly.
+
+</AccordionItem>
+
+<AccordionItem title="What does the CI Agent post on my PR?">
+
+After a test failure, the CI Agent posts a comment with the root cause in plain language, a trace showing the execution chain from failure back to cause, and a suggested code fix with file and line references.
+
+</AccordionItem>
+
+<AccordionItem title="Does using Replay Browser slow down my CI test runs?">
+
+No. Replay Browser is built on Chromium — the same engine as Chrome — and records the runtime with minimal overhead. Recordings are uploaded asynchronously after the run completes.
+
+</AccordionItem>
+
+</Accordion>
+
+<QuickLinks title="Get started" description="Choose the Replay QA workflow that fits how you build.">
+
+<QuickLink
+  title="Run Replay QA stand-alone"
+  icon="rocket"
+  href="/basics/getting-started/record-your-app"
+  description="Point Replay QA at a URL and let it find bugs autonomously."
+/>
+
+<QuickLink
+  title="Set up the CI Agent"
+  icon="pullrequest"
+  href="/basics/getting-started/record-your-playwright-tests/github-actions"
+  description="Get root cause analysis and suggested fixes posted directly on every failing PR."
+/>
+
+<QuickLink
+  title="Replay MCP"
+  icon="terminal"
+  href="/basics/replay-mcp/overview"
+  description="Connect time-travel debugging to your coding agent in the IDE."
+/>
+
+</QuickLinks>

--- a/src/app/basics/replay-qa/source-maps/page.mdx
+++ b/src/app/basics/replay-qa/source-maps/page.mdx
@@ -1,0 +1,108 @@
+---
+title: Publishing with source maps
+description: How source maps improve Replay QA's root cause analysis and suggested fixes, and how to configure your build to publish them.
+---
+
+When you build a web app for production, your source code is compiled, bundled, and often minified. The browser runs the transformed output — not the code you wrote. Source maps are files that connect that compiled output back to your original source.
+
+Replay QA runs against your deployed app. When source maps are available, every analysis Replay performs — from tracing a failure through the call stack to pinpointing the line that caused a bug — can reference your original code. Without them, Replay is working with minified identifiers and compiled output.
+
+## What source maps unlock in Replay QA
+
+**More precise root cause analysis.** When Replay time-travels a failing test recording, it traces the execution chain back to the source. With source maps, that trace cites your actual component names, function names, and file paths — not `a()`, `b()`, or `chunk-abc123.js`.
+
+**Actionable suggested fixes.** Bug reports include suggested fixes with file and line references. Source maps ensure those references point to the right place in your codebase, so a coding agent or developer can act on them directly.
+
+**Full React analysis.** Replay QA's React analysis layer — render tracking, performance profiling, effect analysis, render cause tracing — works by instrumenting specific functions inside React's source code. This requires readable function names. React 19 ships with sourcemaps that make this work automatically. React 18.3 requires a small extra step (see below).
+
+**Better test generation.** When Replay QA writes Playwright tests for your app, it can reference selectors and interactions tied to real component names and code paths rather than opaque compiled output.
+
+## Configuring your build
+
+### Publicly served source maps — simplest, works automatically
+
+If your app serves source maps publicly alongside the JS files, Replay QA discovers and uses them automatically via the `sourceMappingURL` references embedded in each bundle. No upload step needed.
+
+Configure your build tool to emit and serve source maps:
+
+<Tabs labels={["Next.js", "Vite", "Webpack"]}>
+
+<Tab>
+
+```js fileName="next.config.js"
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  productionBrowserSourceMaps: true,
+}
+
+module.exports = nextConfig
+```
+
+</Tab>
+
+<Tab>
+
+```js fileName="vite.config.js"
+export default {
+  build: {
+    sourcemap: true,
+  },
+}
+```
+
+</Tab>
+
+<Tab>
+
+```js fileName="webpack.config.js"
+module.exports = {
+  devtool: 'source-map',
+}
+```
+
+</Tab>
+
+</Tabs>
+
+Deploy with these settings and Replay QA will pick up the source maps on its own.
+
+### Private source maps — for apps that don't expose source to end users
+
+If you want source maps available to Replay but don't want to expose them publicly (a common production concern), upload them to Replay ahead of time:
+
+1. Configure your build to emit source maps (same settings above)
+2. Upload them to Replay using the CLI after the build:
+
+```sh
+npm run build
+npx replayio upload-source-maps --group <version-or-sha> <buildOutputDir>
+```
+
+3. Strip or omit the `sourceMappingURL` comment from your build output so the maps aren't publicly reachable
+
+Set `REPLAY_API_KEY` in your environment so the CLI can authenticate. API keys are available in [Team Settings](/reference/ci-workflows/generate-api-key). For Webpack, the [`@replayio/sourcemap-upload-webpack-plugin`](https://www.npmjs.com/package/@replayio/sourcemap-upload-webpack-plugin) handles upload automatically as part of the build. See the [Uploading source maps reference](/reference/replay-cli/source-maps) for full details.
+
+### React 18.3 — extra step required
+
+React 19 ships unminified production artifacts, so standard source maps work. React 18 shipped pre-minified builds with no source maps, which means Replay cannot read the internal function names it needs for React analysis.
+
+The [`@acemarke/react-prod-sourcemaps`](https://github.com/markerikson/react-prod-sourcemaps) package provides pre-built source maps for React 18's production artifacts and a build plugin that wires them in automatically. See [React Version Support](/reference/integrations/frameworks-libraries/react-sourcemaps) for setup instructions.
+
+## Getting your coding agent to set this up
+
+Paste the following prompt into your coding agent to have it configure source map emission for your project:
+
+```text
+Configure this project to publish source maps so Replay QA can use them.
+
+Check which bundler or framework is in use (Next.js, Vite, Webpack, etc.) and apply the appropriate setting to emit and publicly serve source maps:
+- Next.js: set `productionBrowserSourceMaps: true` in next.config.js
+- Vite: set `build.sourcemap: true` in vite.config.js
+- Webpack: set `devtool: 'source-map'` in webpack.config.js
+
+Replay QA discovers publicly served source maps automatically — no upload step is needed unless we specifically want to keep source maps private.
+
+If the project uses React 18.3 (not React 19), also install @acemarke/react-prod-sourcemaps and configure it per the package README, so Replay can instrument React internals for component analysis.
+
+Make the minimum changes needed — don't restructure the build config beyond what's required.
+```

--- a/src/components/Fence.tsx
+++ b/src/components/Fence.tsx
@@ -18,7 +18,7 @@ const CopyButton = ({
     <Icon
       className={clsx(
         className,
-        'absolute right-4 top-4 h-4 w-4 cursor-pointer text-white text-opacity-40 hover:text-opacity-100',
+        'absolute right-4 top-4 h-4 w-4 cursor-pointer rounded bg-gray-900/80 text-white text-opacity-40 hover:text-opacity-100 dark:bg-zinc-900/80',
       )}
       icon="clipboard"
       onClick={() => {
@@ -47,6 +47,7 @@ export function Fence({
 }) {
   const highlightedLines = sortHighlights(highlight)
   language === 'sh' ? (fileName = 'Terminal') : null
+  const isPlainText = language === 'text'
   return (
     <Highlight
       code={children.trimEnd()}
@@ -54,7 +55,14 @@ export function Fence({
       theme={{ plain: {}, styles: [] }}
     >
       {({ className, style, tokens, getTokenProps }) => (
-        <pre className={clsx(className, 'relative mt-0')} style={style}>
+        <pre
+          className={clsx(
+            className,
+            'relative mt-0',
+            isPlainText && 'overflow-x-hidden whitespace-pre-wrap break-words',
+          )}
+          style={style}
+        >
           <CopyButton>{children}</CopyButton>
           {fileName && (
             <div className="mb-2 border-b border-white border-opacity-20 pb-3 pr-4 text-xs text-white text-opacity-80">
@@ -75,6 +83,7 @@ export function Fence({
                     highlightedLines.includes(lineIndex + 1) &&
                       'bg-gray-400 bg-opacity-15',
                     'px-3',
+                    isPlainText && 'pr-10',
                   )}
                 >
                   <>

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -15,6 +15,21 @@ type NavigationNames = 'basics' | 'learn' | 'reference'
 export const navigation: Record<NavigationNames, NavigationItem[]> = {
   basics: [
     {
+      title: 'Replay QA',
+      icon: 'beaker',
+      defaultOpen: true,
+      links: [
+        {
+          title: 'Overview',
+          href: '/basics/replay-qa/overview',
+        },
+        {
+          title: 'Publishing with source maps',
+          href: '/basics/replay-qa/source-maps',
+        },
+      ],
+    },
+    {
       title: 'Getting Started',
       icon: 'home',
       defaultOpen: true,


### PR DESCRIPTION
## Summary

- Adds a new **Replay QA** section to the basics nav with two pages:
  - **Overview** — describes the three usage modes (stand-alone, coding agent loop, CI pipeline integration), includes copyable coding agent prompt, CTAs, and cross-links to relevant docs
  - **Publishing with source maps** — explains why source maps improve QA results, with build config examples (Next.js/Vite/Webpack) and separate guidance for publicly served vs. privately uploaded maps; includes a copyable coding agent prompt
- Fixes a **Fence component** bug where `text` language code blocks allowed horizontal scrolling and the copy button was invisible when text ran beneath it

## Test plan

- [ ] Visit `/basics/replay-qa/overview` — page loads, nav section visible, CTA button and cross-links work
- [ ] Visit `/basics/replay-qa/source-maps` — page loads, tabs render, coding agent prompt copy button works
- [ ] Confirm other code blocks (shell, JS) are unaffected by the Fence change