### PR TITLE
Default to Replay QA overview, add GitHub-repo section and video

### DIFF
--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -14,12 +14,14 @@ import { Steps } from '@/components/Steps'
 import { Tab, Tabs } from '@/components/Tabs'
 import { TwoColumns } from '@/components/TwoColumns'
 import { Video } from '@/components/Video'
+import { YouTube } from '@/components/YouTube'
 
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {
     Callout,
     Figure,
     Video,
+    YouTube,
     Steps,
     Tabs,
     Tab,

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -43,6 +43,11 @@ const nextConfig = {
   async redirects() {
     return [
       {
+        source: '/',
+        destination: '/basics/replay-qa/overview',
+        permanent: false,
+      },
+      {
         source: '/getting-started/record-your-first-replay',
         destination: '/quickstart',
         permanent: true,

--- a/src/app/basics/replay-qa/overview/page.mdx
+++ b/src/app/basics/replay-qa/overview/page.mdx
@@ -3,6 +3,8 @@ title: Replay QA Overview
 description: An autonomous app testing tool that explores your web app, writes tests, captures Replay recordings, and delivers root cause analysis and suggested fixes for every bug it finds.
 ---
 
+<YouTube id="1yKkDy313rM" title="Replay QA overview" />
+
 Replay QA is an autonomous app testing tool built on Replay's time-travel debugging engine. Point it at a web app and it explores the application, discovers user journeys, writes Playwright tests, executes them while capturing full runtime recordings, and uncovers bugs — delivering a detailed root cause analysis and suggested fix for every issue it finds.
 
 There are three ways to use Replay QA depending on your workflow.
@@ -37,6 +39,17 @@ Your job:
 3. For each open bug, read its full root-caused report and apply the fix directly in the codebase, then mark it fixed via the API.
 4. Keep looping until no open bugs remain.
 ```
+
+## Connected to a GitHub repo
+
+Connect Replay QA directly to a GitHub repository and let it test every change as it lands. From your Replay QA project, install the GitHub App and authorize the repository you want to test — no CI configuration or workflow files required.
+
+Once connected, Replay QA watches the repo and automatically kicks off a new test run whenever code changes:
+
+- **On every push to `main`** — Replay QA explores the latest version of your app and runs its tests against it, so regressions are caught the moment they merge.
+- **On every pull request** — each PR triggers its own test run, and Replay QA reports what it finds back on the PR before the change is merged.
+
+For each run, Replay QA captures full Replay recordings, time-travels any failure back to its root cause, and delivers a detailed analysis with a suggested fix — right where you're already reviewing code.
 
 ## Integrated into your CI pipeline
 

--- a/src/components/YouTube.tsx
+++ b/src/components/YouTube.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+
+interface YouTubeProps {
+  /** The YouTube video ID (e.g. "1yKkDy313rM"). */
+  id: string
+  /** Optional accessible title for the embedded player. */
+  title?: string
+}
+
+export const YouTube: React.FC<YouTubeProps> = ({
+  id,
+  title = 'YouTube video player',
+}) => {
+  return (
+    <div
+      className="relative my-6 h-0 w-full overflow-clip rounded-xl border border-transparent"
+      style={{ paddingBottom: '56.25%' }}
+    >
+      <iframe
+        className="absolute inset-0"
+        style={{ border: 0, height: '100%', width: '100%' }}
+        src={`https://www.youtube-nocookie.com/embed/${id}`}
+        title={title}
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        referrerPolicy="strict-origin-when-cross-origin"
+        allowFullScreen
+      />
+    </div>
+  )
+}
+
+export default YouTube


### PR DESCRIPTION
- Redirect / to the Replay QA overview so it's the docs landing page
- Add a "Connected to a GitHub repo" section explaining push/PR triggers
- Embed the overview walkthrough video via a new YouTube component