### PR TITLE
Add Launch Replay QA CTA to Connect to a GitHub repo section

### DIFF
--- a/src/app/basics/replay-qa/overview/page.mdx
+++ b/src/app/basics/replay-qa/overview/page.mdx
@@ -35,6 +35,8 @@ Once connected, Replay QA watches the repo and automatically kicks off a new tes
 
 For each run, Replay QA captures full Replay recordings, time-travels any failure back to its root cause, and delivers a detailed analysis with a suggested fix — right where you're already reviewing code.
 
+<Button href="https://qa.replay.io">Launch Replay QA</Button>
+
 ## Ask your coding agent
 
 Give your coding agent the prompt below and it will use the Replay QA REST API to create a new project for your app, poll for status as Replay QA explores and tests the application, and ingest the resulting bug reports — each packaged with the runtime context and root cause detail your agent needs to go straight to a fix. It keeps looping until no open bugs remain.


### PR DESCRIPTION
Adds the "Launch Replay QA" CTA button to the "Connect to a GitHub repo" section, matching the one in the "Stand-alone" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)